### PR TITLE
Enable manual workflow triggering

### DIFF
--- a/.github/workflows/R-CMD-check.yml
+++ b/.github/workflows/R-CMD-check.yml
@@ -1,6 +1,7 @@
 # For help debugging build failures open an issue on the RStudio community with the 'github-actions' tag.
 # https://community.rstudio.com/new-topic?category=Package%20development&tags=github-actions
 on:
+  workflow_dispatch:
   push:
     branches:
       - main

--- a/.github/workflows/lintr.yaml
+++ b/.github/workflows/lintr.yaml
@@ -1,4 +1,5 @@
 on:
+  workflow_dispatch:
   push:
     branches:
       - main

--- a/.github/workflows/pkgdown.yml
+++ b/.github/workflows/pkgdown.yml
@@ -1,4 +1,5 @@
 on:
+  workflow_dispatch:
   push:
     branches:
       - main


### PR DESCRIPTION
Unlike what I expected the workflows still cannot be triggered manually. I suppose that's because these changes are not yet on master. Thus, let's try merging to master and see if what happens.