### PR TITLE
Create codecov workflow

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -55,4 +55,4 @@ jobs:
       - name: Upload codecov report
         run: |
           covr::codecov()
-        shel: Rscript {0}
+        shell: Rscript {0}


### PR DESCRIPTION
@slamao After doing some more research it seems to be best practice to have a CI workflow that calls `covr::codevoc()` which then uploads the report to codecov.io (which you can then access via the badge link).