### PR TITLE
remove options not used in gh-action

### DIFF
--- a/.github/workflows/r-pkg-validation.yml
+++ b/.github/workflows/r-pkg-validation.yml
@@ -21,13 +21,6 @@ jobs:
 
       - name: Build report 🏗
         uses: insightsengineering/r-pkg-validation@main
-        with:
-          # R package root path, in case your R package is within a subdirectory of the repo
-          report_pkg_dir: "."
-          # Template location
-          report_template_path: ".github/validation_template.rmd"
-          # Report format - provided to `rmarkdown::render` `output_format`
-          report_rmarkdown_format: "pdf_document"
 
       # Upload the validation report to the release
       - name: Upload report to release 🔼


### PR DESCRIPTION
Hey @thomas-neitmann - apologies, didn't look closely at the `yaml` that was already on `devel`. I deleted some of the options as defaults would be sufficient:

- `report_pkg_dir: "."` this is the default, so is correct and doesn't have to be deleted, but also not needed
- `report_template_path: ".github/validation_template.rmd"` **this needs to be deleted** (or changed to the default)
- `report_rmarkdown_format: "pdf_document"`  this is the default, so is correct and doesn't have to be deleted, but also not needed