### PR TITLE
Update derive_vars_dtm to change min_dates with max_dates for lapply …

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -45,6 +45,8 @@ to specify the unit of the input age (#569)
 
 - `derive_vars_dtm()` no longer shifts the time of the input `--DTC` variable (#436)
 
+- `derive_vars_dtm()` Change the min_dates with max_dates in the lapply statement when computing max_dates (#687)
+
 ## Documentation
 
 - New vignette [Creating a BDS Time-to-Event ADaM](../articles/bds_tte.html) (#549)

--- a/R/derive_date_vars.R
+++ b/R/derive_date_vars.R
@@ -699,7 +699,7 @@ derive_vars_dtm <- function(dataset,
     date_imputation = date_imputation,
     time_imputation = time_imputation,
     min_dates = lapply(min_dates, eval_tidy, data = mask),
-    max_dates = lapply(min_dates, eval_tidy, data = mask)
+    max_dates = lapply(max_dates, eval_tidy, data = mask)
   )
 
   if (flag_imputation %in% c("both", "date") ||

--- a/tests/testthat/test-derive_vars_dtm.R
+++ b/tests/testthat/test-derive_vars_dtm.R
@@ -233,3 +233,36 @@ test_that("Issue a warning if --DTM already exists", {
   )
 
 })
+
+test_that("max_dates and min_dates are working as expected", {
+  expected_output <- tibble::tribble(
+    ~XXSTDTC, ~ASTDTM, ~ASTDTF, ~ASTTMF,
+    "2019-07-18T15:25:40", ymd_hms("2019-07-18T15:25:40"), NA_character_, NA_character_,
+    "2019-07-18T15:25", ymd_hms("2019-07-18T15:25:00"), NA_character_, "S",
+    "2019-07-18T15", ymd_hms("2019-07-18T15:00:00"), NA_character_, "M",
+    "2019-07-18", ymd_hms("2019-07-18T00:00:00"), NA_character_, "H",
+    "2019-02", ymd_hms("2019-02-20T00:00:00"), "D", "H",
+    "2019", ymd_hms("2019-06-10T00:00:00"), "M", "H",
+    "2019---07", ymd_hms("2019-06-10T00:00:00"), "M", "H"
+  ) %>%
+    mutate(ASTDTM = as_iso_dtm(ASTDTM))
+
+  input1 <- input %>%
+    mutate(MAX = ymd("2019-06-10"),
+           MIN = ymd('2019-02-20'))
+
+  actual_output <- derive_vars_dtm(
+    input1,
+    new_vars_prefix = "AST",
+    dtc = XXSTDTC,
+    date_imputation = "MID",
+    max_dates = vars(MAX),
+    min_dates = vars(MIN)
+  )
+
+  expect_equal(
+    expected_output,
+    actual_output %>% select(-c(MAX, MIN))
+  )
+
+})

--- a/tests/testthat/test-derive_vars_dtm.R
+++ b/tests/testthat/test-derive_vars_dtm.R
@@ -205,6 +205,7 @@ test_that("No re-derivation is done if --DTF variable already exists", {
 })
 
 test_that("Issue a warning if --DTM already exists", {
+
   expected_output <- tibble::tribble(
     ~XXSTDTC, ~ASTDTM, ~ASTDTF, ~ASTTMF,
     "2019-07-18T15:25:40", ymd_hms("2019-07-18T15:25:40"), NA_character_, NA_character_,
@@ -217,17 +218,18 @@ test_that("Issue a warning if --DTM already exists", {
   ) %>%
     mutate(ASTDTM = as_iso_dtm(ASTDTM))
 
-  actual_output <- derive_vars_dtm(
-    input,
+  expected_output1 <- derive_vars_dtm(
+    expected_output,
     new_vars_prefix = "AST",
     dtc = XXSTDTC,
-    date_imputation = "MID"
+    date_imputation = "MID",
+    max_dates = vars(ASTDTM)
   )
 
 
   expect_equal(
     expected_output,
-    actual_output
+    expected_output1
   )
 
 })

--- a/tests/testthat/test-derive_vars_dtm.R
+++ b/tests/testthat/test-derive_vars_dtm.R
@@ -203,3 +203,31 @@ test_that("No re-derivation is done if --DTF variable already exists", {
   expect_equal(expected_output, actual_output)
 
 })
+
+test_that("Issue a warning if --DTM already exists", {
+  expected_output <- tibble::tribble(
+    ~XXSTDTC, ~ASTDTM, ~ASTDTF, ~ASTTMF,
+    "2019-07-18T15:25:40", ymd_hms("2019-07-18T15:25:40"), NA_character_, NA_character_,
+    "2019-07-18T15:25", ymd_hms("2019-07-18T15:25:00"), NA_character_, "S",
+    "2019-07-18T15", ymd_hms("2019-07-18T15:00:00"), NA_character_, "M",
+    "2019-07-18", ymd_hms("2019-07-18T00:00:00"), NA_character_, "H",
+    "2019-02", ymd_hms("2019-02-15T00:00:00"), "D", "H",
+    "2019", ymd_hms("2019-06-15T00:00:00"), "M", "H",
+    "2019---07", ymd_hms("2019-06-15T00:00:00"), "M", "H"
+  ) %>%
+    mutate(ASTDTM = as_iso_dtm(ASTDTM))
+
+  actual_output <- derive_vars_dtm(
+    input,
+    new_vars_prefix = "AST",
+    dtc = XXSTDTC,
+    date_imputation = "Date"
+  )
+
+
+  expect_equal(
+    expected_output,
+    actual_output
+  )
+
+})

--- a/tests/testthat/test-derive_vars_dtm.R
+++ b/tests/testthat/test-derive_vars_dtm.R
@@ -221,7 +221,7 @@ test_that("Issue a warning if --DTM already exists", {
     input,
     new_vars_prefix = "AST",
     dtc = XXSTDTC,
-    date_imputation = "Date"
+    date_imputation = "MID"
   )
 
 


### PR DESCRIPTION
Update derive_vars_dtm to put max_dates instead of min_dates when calling lapply
Update the NEWS to describe the bug
Add unit test to cover the case