### PR TITLE
change to versioned gh-action

### DIFF
--- a/.github/workflows/r-pkg-validation.yml
+++ b/.github/workflows/r-pkg-validation.yml
@@ -20,7 +20,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Build report 🏗
-        uses: insightsengineering/r-pkg-validation@main
+        uses: insightsengineering/thevalidatoR@v1.0
 
       # Upload the validation report to the release
       - name: Upload report to release 🔼


### PR DESCRIPTION
also noticed we had it pointing it at an alias of the gh-action, but that doesn't matter (fixed it anyway).

with the direct link rather than alias, and locked to a version, it's building now here: https://github.com/epijim/admiral/runs/4441845759?check_suite_focus=true

this will close #719 