### PR TITLE
Test GH package installation for validation

### DIFF
--- a/.github/workflows/r-pkg-validation.yml
+++ b/.github/workflows/r-pkg-validation.yml
@@ -3,13 +3,16 @@ name: R Package Validation report
 on: # Run this action when a release is published
   release:
     types: [published]
+  pull_request_target:
+    branches:
+      - main
 
 jobs:
   r-pkg-validation:
     name: Create report 📃
     runs-on: ubuntu-latest
     container:
-      image: rocker/verse:4.1.1
+      image: rocker/verse:4.1.2
     # Set Github token permissions
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
@@ -22,7 +25,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Build report 🏗
-        uses: insightsengineering/thevalidatoR@v1.1.2
+        uses: insightsengineering/thevalidatoR@v1
 
       # Upload the validation report to the release
       - name: Upload report to release 🔼

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -126,3 +126,4 @@ Collate:
     'tte_sources.R'
     'user_helpers.R'
     'warnings.R'
+Remotes: pharmaverse/admiral.test


### PR DESCRIPTION
Given that `admiral.test` is in the `pharmaverse` org, simply use the `Remotes` field in the DESCRIPTION to install so that the validation reports pass.
