### PR TITLE
Fix the Roxygen workflow

### DIFF
--- a/.github/workflows/man-pages.yml
+++ b/.github/workflows/man-pages.yml
@@ -36,7 +36,7 @@ jobs:
           fetch-depth: 0
 
       - name: Fetch PR 🐕
-        if: ${{ github.event.issue.pull_request }}
+        if: github.event_name == 'pull_request'
         uses: r-lib/actions/pr-fetch@v1
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/man-pages.yml
+++ b/.github/workflows/man-pages.yml
@@ -36,6 +36,7 @@ jobs:
           fetch-depth: 0
 
       - name: Fetch PR 🐕
+        if: ${{ github.event.issue.pull_request }}
         uses: r-lib/actions/pr-fetch@v1
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/man-pages.yml
+++ b/.github/workflows/man-pages.yml
@@ -87,12 +87,6 @@ jobs:
           sink(type = "message")
           logs <- readLines(logfile)
           error_marker <- grep("Error:", logs)
-          warnings_marker <- grep("Warning message", logs)
-          if (length(warnings_marker) > 0) {
-            cat("⚠ One or more warnings were generated during the roxygen build:\n")
-            cat(logs[warnings_marker[[1]]:length(logs)], sep = "\n")
-            stop("Please 🙏 fix the warnings shown below this message 👇")
-          }
           if (length(error_marker) > 0) {
             cat("☠ One or more errors were generated during the roxygen build:\n")
             cat(logs[error_marker[[1]]:length(logs)], sep = "\n")

--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,6 @@ Meta
 admiral.Rcheck/
 admiral*.tar.gz
 admiral*.tgz
+
+# vscode
+.vscode

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -48,7 +48,7 @@ License: Apache License (>= 2)
 Encoding: UTF-8
 LazyData: true
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.1.2
+RoxygenNote: 7.2.0
 Depends: R (>= 3.5)
 Imports:
     assertthat,

--- a/man/admiral-package.Rd
+++ b/man/admiral-package.Rd
@@ -22,6 +22,7 @@ Authors:
   \item Teckla Akinyi
   \item Andrew Smith
   \item Konstantina Koukourikou
+  \item Ross Farrugia
   \item Eric Simms
   \item Annie Yang
   \item Robin Koeger
@@ -29,8 +30,12 @@ Authors:
   \item Ojesh Upadhyay
   \item Jack McGavigan
   \item Kamila Duniec
-  \item Gayatri  G
+  \item Gayatri G
   \item Alana Harris
+  \item Mahdi About
+  \item Pooja Kumari
+  \item Claudia Carlucci
+  \item Daniil Stefonishin
 }
 
 Other contributors:
@@ -38,7 +43,6 @@ Other contributors:
   \item Michael Thorpe [contributor]
   \item Pavan Kumar [contributor]
   \item Hamza Rahal [contributor]
-  \item Ross Farrugia [contributor]
   \item Alice Ehmann [contributor]
   \item Tom Ratford [contributor]
   \item Vignesh Thanikachalam [contributor]

--- a/man/admiral-package.Rd
+++ b/man/admiral-package.Rd
@@ -6,9 +6,9 @@
 \alias{admiral-package}
 \title{admiral: ADaM in R Asset Library}
 \description{
-\if{html}{\figure{logo.png}{options: align='right' alt='logo' width='120'}}
+\if{html}{\figure{logo.png}{options: style='float: right' alt='logo' width='120'}}
 
-A toolbox for programming Clinical Data Standards Interchange Consortium (CDISC) compliant Analysis Data Model (ADaM) datasets in R. ADaM datasets are a mandatory part of any New Drug or Biologics License Application submitted to the United States Food and Drug Administration (FDA). Analysis derivations are implemented in accordance with the "Analysis Data Model Implementation Guide" (CDISC Analysis Data Model Team, 2021, <https://www.cdisc.org/standards/foundational/adam/adamig-v1-3-release-package>).
+A toolbox for programming Clinical Data Standards Interchange Consortium (CDISC) compliant Analysis Data Model (ADaM) datasets in R. ADaM datasets are a mandatory part of any New Drug or Biologics License Application submitted to the United States Food and Drug Administration (FDA). Analysis derivations are implemented in accordance with the "Analysis Data Model Implementation Guide" (CDISC Analysis Data Model Team, 2021, \url{https://www.cdisc.org/standards/foundational/adam/adamig-v1-3-release-package}).
 }
 \author{
 \strong{Maintainer}: Thomas Neitmann \email{thomas.neitmann@roche.com}

--- a/man/convert_date_to_dtm.Rd
+++ b/man/convert_date_to_dtm.Rd
@@ -55,7 +55,9 @@ range of possible dates of the \code{dtc} value are considered. The possible dat
 are defined by the missing parts of the \code{dtc} date (see example below). This
 ensures that the non-missing parts of the \code{dtc} date are not changed.
 A date or date-time object is expected.
-For example\preformatted{impute_dtc(
+For example
+
+\if{html}{\out{<div class="sourceCode">}}\preformatted{impute_dtc(
   "2020-11",
   min_dates = list(
     ymd_hms("2020-12-06T12:12:12"),
@@ -63,7 +65,7 @@ For example\preformatted{impute_dtc(
    ),
   date_imputation = "first"
 )
-}
+}\if{html}{\out{</div>}}
 
 returns \code{"2020-11-11T11:11:11"} because the possible dates for \code{"2020-11"}
 range from \code{"2020-11-01T00:00:00"} to \code{"2020-11-30T23:59:59"}. Therefore

--- a/man/convert_dtc_to_dt.Rd
+++ b/man/convert_dtc_to_dt.Rd
@@ -45,7 +45,9 @@ range of possible dates of the \code{dtc} value are considered. The possible dat
 are defined by the missing parts of the \code{dtc} date (see example below). This
 ensures that the non-missing parts of the \code{dtc} date are not changed.
 A date or date-time object is expected.
-For example\preformatted{impute_dtc(
+For example
+
+\if{html}{\out{<div class="sourceCode">}}\preformatted{impute_dtc(
   "2020-11",
   min_dates = list(
     ymd_hms("2020-12-06T12:12:12"),
@@ -53,7 +55,7 @@ For example\preformatted{impute_dtc(
    ),
   date_imputation = "first"
 )
-}
+}\if{html}{\out{</div>}}
 
 returns \code{"2020-11-11T11:11:11"} because the possible dates for \code{"2020-11"}
 range from \code{"2020-11-01T00:00:00"} to \code{"2020-11-30T23:59:59"}. Therefore

--- a/man/convert_dtc_to_dtm.Rd
+++ b/man/convert_dtc_to_dtm.Rd
@@ -57,7 +57,9 @@ range of possible dates of the \code{dtc} value are considered. The possible dat
 are defined by the missing parts of the \code{dtc} date (see example below). This
 ensures that the non-missing parts of the \code{dtc} date are not changed.
 A date or date-time object is expected.
-For example\preformatted{impute_dtc(
+For example
+
+\if{html}{\out{<div class="sourceCode">}}\preformatted{impute_dtc(
   "2020-11",
   min_dates = list(
     ymd_hms("2020-12-06T12:12:12"),
@@ -65,7 +67,7 @@ For example\preformatted{impute_dtc(
    ),
   date_imputation = "first"
 )
-}
+}\if{html}{\out{</div>}}
 
 returns \code{"2020-11-11T11:11:11"} because the possible dates for \code{"2020-11"}
 range from \code{"2020-11-01T00:00:00"} to \code{"2020-11-30T23:59:59"}. Therefore

--- a/man/derive_disposition_status.Rd
+++ b/man/derive_disposition_status.Rd
@@ -36,14 +36,16 @@ A variable name is expected (e.g. \code{DSDECOD}).}
 
 \item{format_new_var}{The format used to derive the status.
 
-Default: \code{format_eoxxstt_default()} defined as:\preformatted{format_eoxxstt_default <- function(x) \{
+Default: \code{format_eoxxstt_default()} defined as:
+
+\if{html}{\out{<div class="sourceCode">}}\preformatted{format_eoxxstt_default <- function(x) \{
   case_when(
     x == "COMPLETED" ~ "COMPLETED",
     x != "COMPLETED" & !is.na(x) ~ "DISCONTINUED",
     TRUE ~ "ONGOING"
   )
 \}
-}
+}\if{html}{\out{</div>}}
 
 where \code{x} is the \code{status_var.}}
 

--- a/man/derive_var_disposition_status.Rd
+++ b/man/derive_var_disposition_status.Rd
@@ -36,14 +36,16 @@ A variable name is expected (e.g. \code{DSDECOD}).}
 
 \item{format_new_var}{The format used to derive the status.
 
-Default: \code{format_eoxxstt_default()} defined as:\preformatted{format_eoxxstt_default <- function(x) \{
+Default: \code{format_eoxxstt_default()} defined as:
+
+\if{html}{\out{<div class="sourceCode">}}\preformatted{format_eoxxstt_default <- function(x) \{
   case_when(
     x == "COMPLETED" ~ "COMPLETED",
     x != "COMPLETED" & !is.na(x) ~ "DISCONTINUED",
     TRUE ~ "ONGOING"
   )
 \}
-}
+}\if{html}{\out{</div>}}
 
 where \code{x} is the \code{status_var.}}
 

--- a/man/derive_var_extreme_dt.Rd
+++ b/man/derive_var_extreme_dt.Rd
@@ -96,8 +96,10 @@ admiral_dm \%>\%
   derive_var_extreme_dt(
     new_var = LSTALVDT,
     ae_start, ae_end, lb_date, adsl_date,
-    source_datasets = list(adsl = admiral_adsl,
-    ae = admiral_ae, lb = admiral_lb),
+    source_datasets = list(
+      adsl = admiral_adsl,
+      ae = admiral_ae, lb = admiral_lb
+    ),
     mode = "last"
   ) \%>\%
   select(USUBJID, LSTALVDT)
@@ -149,8 +151,10 @@ admiral_dm \%>\%
   derive_var_extreme_dt(
     new_var = LSTALVDT,
     ae_start, ae_end, lb_date, adsl_date,
-    source_datasets = list(adsl = admiral_adsl,
-    ae = admiral_ae, lb = admiral_lb),
+    source_datasets = list(
+      adsl = admiral_adsl,
+      ae = admiral_ae, lb = admiral_lb
+    ),
     mode = "last"
   ) \%>\%
   select(USUBJID, LSTALVDT, LALVDOM, LALVSEQ, LALVVAR)

--- a/man/derive_var_extreme_dtm.Rd
+++ b/man/derive_var_extreme_dtm.Rd
@@ -98,8 +98,10 @@ admiral_dm \%>\%
   derive_var_extreme_dtm(
     new_var = LSTALVDTM,
     ae_start, ae_end, lb_date, adsl_date,
-    source_datasets = list(adsl = admiral_adsl,
-    ae = admiral_ae, lb = admiral_lb),
+    source_datasets = list(
+      adsl = admiral_adsl,
+      ae = admiral_ae, lb = admiral_lb
+    ),
     mode = "last"
   ) \%>\%
   select(USUBJID, LSTALVDTM)
@@ -154,8 +156,10 @@ admiral_dm \%>\%
   derive_var_extreme_dtm(
     new_var = LSTALVDTM,
     ae_start, ae_end, lb_date, adsl_date,
-    source_datasets = list(adsl = admiral_adsl,
-    ae = admiral_ae, lb = admiral_lb),
+    source_datasets = list(
+      adsl = admiral_adsl,
+      ae = admiral_ae, lb = admiral_lb
+    ),
     mode = "last"
   ) \%>\%
   select(USUBJID, LSTALVDTM, LALVDOM, LALVSEQ, LALVVAR)

--- a/man/derive_vars_dt.Rd
+++ b/man/derive_vars_dt.Rd
@@ -63,7 +63,9 @@ range of possible dates of the \code{dtc} value are considered. The possible dat
 are defined by the missing parts of the \code{dtc} date (see example below). This
 ensures that the non-missing parts of the \code{dtc} date are not changed.
 A date or date-time object is expected.
-For example\preformatted{impute_dtc(
+For example
+
+\if{html}{\out{<div class="sourceCode">}}\preformatted{impute_dtc(
   "2020-11",
   min_dates = list(
     ymd_hms("2020-12-06T12:12:12"),
@@ -71,7 +73,7 @@ For example\preformatted{impute_dtc(
    ),
   date_imputation = "first"
 )
-}
+}\if{html}{\out{</div>}}
 
 returns \code{"2020-11-11T11:11:11"} because the possible dates for \code{"2020-11"}
 range from \code{"2020-11-01T00:00:00"} to \code{"2020-11-30T23:59:59"}. Therefore

--- a/man/derive_vars_dtm.Rd
+++ b/man/derive_vars_dtm.Rd
@@ -82,7 +82,9 @@ range of possible dates of the \code{dtc} value are considered. The possible dat
 are defined by the missing parts of the \code{dtc} date (see example below). This
 ensures that the non-missing parts of the \code{dtc} date are not changed.
 A date or date-time object is expected.
-For example\preformatted{impute_dtc(
+For example
+
+\if{html}{\out{<div class="sourceCode">}}\preformatted{impute_dtc(
   "2020-11",
   min_dates = list(
     ymd_hms("2020-12-06T12:12:12"),
@@ -90,7 +92,7 @@ For example\preformatted{impute_dtc(
    ),
   date_imputation = "first"
 )
-}
+}\if{html}{\out{</div>}}
 
 returns \code{"2020-11-11T11:11:11"} because the possible dates for \code{"2020-11"}
 range from \code{"2020-11-01T00:00:00"} to \code{"2020-11-30T23:59:59"}. Therefore

--- a/man/derive_vars_merged.Rd
+++ b/man/derive_vars_merged.Rd
@@ -112,9 +112,11 @@ with respect to the by variables and the order.
 
 If the uniqueness check fails, the specified message is displayed.
 
-\emph{Default}:\preformatted{paste("Dataset `dataset_add` contains duplicate records with respect to",
+\emph{Default}:
+
+\if{html}{\out{<div class="sourceCode">}}\preformatted{paste("Dataset `dataset_add` contains duplicate records with respect to",
       enumerate(vars2chr(by_vars))
-}}
+}\if{html}{\out{</div>}}}
 }
 \value{
 The output dataset contains all observations and variables of the

--- a/man/derive_vars_merged_dt.Rd
+++ b/man/derive_vars_merged_dt.Rd
@@ -121,7 +121,9 @@ range of possible dates of the \code{dtc} value are considered. The possible dat
 are defined by the missing parts of the \code{dtc} date (see example below). This
 ensures that the non-missing parts of the \code{dtc} date are not changed.
 A date or date-time object is expected.
-For example\preformatted{impute_dtc(
+For example
+
+\if{html}{\out{<div class="sourceCode">}}\preformatted{impute_dtc(
   "2020-11",
   min_dates = list(
     ymd_hms("2020-12-06T12:12:12"),
@@ -129,7 +131,7 @@ For example\preformatted{impute_dtc(
    ),
   date_imputation = "first"
 )
-}
+}\if{html}{\out{</div>}}
 
 returns \code{"2020-11-11T11:11:11"} because the possible dates for \code{"2020-11"}
 range from \code{"2020-11-01T00:00:00"} to \code{"2020-11-30T23:59:59"}. Therefore
@@ -166,9 +168,11 @@ with respect to the by variables and the order.
 
 If the uniqueness check fails, the specified message is displayed.
 
-\emph{Default}:\preformatted{paste("Dataset `dataset_add` contains duplicate records with respect to",
+\emph{Default}:
+
+\if{html}{\out{<div class="sourceCode">}}\preformatted{paste("Dataset `dataset_add` contains duplicate records with respect to",
       enumerate(vars2chr(by_vars))
-}}
+}\if{html}{\out{</div>}}}
 }
 \value{
 The output dataset contains all observations and variables of the

--- a/man/derive_vars_merged_dtm.Rd
+++ b/man/derive_vars_merged_dtm.Rd
@@ -134,7 +134,9 @@ range of possible dates of the \code{dtc} value are considered. The possible dat
 are defined by the missing parts of the \code{dtc} date (see example below). This
 ensures that the non-missing parts of the \code{dtc} date are not changed.
 A date or date-time object is expected.
-For example\preformatted{impute_dtc(
+For example
+
+\if{html}{\out{<div class="sourceCode">}}\preformatted{impute_dtc(
   "2020-11",
   min_dates = list(
     ymd_hms("2020-12-06T12:12:12"),
@@ -142,7 +144,7 @@ For example\preformatted{impute_dtc(
    ),
   date_imputation = "first"
 )
-}
+}\if{html}{\out{</div>}}
 
 returns \code{"2020-11-11T11:11:11"} because the possible dates for \code{"2020-11"}
 range from \code{"2020-11-01T00:00:00"} to \code{"2020-11-30T23:59:59"}. Therefore
@@ -179,9 +181,11 @@ with respect to the by variables and the order.
 
 If the uniqueness check fails, the specified message is displayed.
 
-\emph{Default}:\preformatted{paste("Dataset `dataset_add` contains duplicate records with respect to",
+\emph{Default}:
+
+\if{html}{\out{<div class="sourceCode">}}\preformatted{paste("Dataset `dataset_add` contains duplicate records with respect to",
       enumerate(vars2chr(by_vars))
-}}
+}\if{html}{\out{</div>}}}
 }
 \value{
 The output dataset contains all observations and variables of the

--- a/man/impute_dtc.Rd
+++ b/man/impute_dtc.Rd
@@ -57,7 +57,9 @@ range of possible dates of the \code{dtc} value are considered. The possible dat
 are defined by the missing parts of the \code{dtc} date (see example below). This
 ensures that the non-missing parts of the \code{dtc} date are not changed.
 A date or date-time object is expected.
-For example\preformatted{impute_dtc(
+For example
+
+\if{html}{\out{<div class="sourceCode">}}\preformatted{impute_dtc(
   "2020-11",
   min_dates = list(
     ymd_hms("2020-12-06T12:12:12"),
@@ -65,7 +67,7 @@ For example\preformatted{impute_dtc(
    ),
   date_imputation = "first"
 )
-}
+}\if{html}{\out{</div>}}
 
 returns \code{"2020-11-11T11:11:11"} because the possible dates for \code{"2020-11"}
 range from \code{"2020-11-01T00:00:00"} to \code{"2020-11-30T23:59:59"}. Therefore

--- a/man/use_ad_template.Rd
+++ b/man/use_ad_template.Rd
@@ -12,12 +12,7 @@ use_ad_template(
 )
 }
 \arguments{
-\item{adam_name}{An ADaM dataset name. You can use any of the available dataset name ADAE
-ADCM
-ADEG
-ADEX
-ADSL
-ADVS, and the dataset name is case-insensitive. The default dataset name is ADSL.}
+\item{adam_name}{An ADaM dataset name. You can use any of the available dataset name ADAE, ADCM, ADEG, ADEX, ADSL, ADVS, and the dataset name is case-insensitive. The default dataset name is ADSL.}
 
 \item{save_path}{Path to save the script.}
 

--- a/vignettes/programming_strategy.Rmd
+++ b/vignettes/programming_strategy.Rmd
@@ -426,7 +426,7 @@ The documentation will be updated at:
 
 + the description level for a function, 
 
-    ```r
+    ```{r, eval=FALSE}
     #' Title of the function
     #'
     #' @description

--- a/vignettes/programming_strategy.Rmd
+++ b/vignettes/programming_strategy.Rmd
@@ -426,7 +426,7 @@ The documentation will be updated at:
 
 + the description level for a function, 
 
-    ```{r, eval=FALSE}
+    ```r
     #' Title of the function
     #'
     #' @description


### PR DESCRIPTION
- [x] Fix the Roxygen workflow
- [x] Use plain markdown code highlighting for unevaluated vignette chunk so the `styler` does not need to reformat it
