### PR TITLE
#1141 First draft of devel to main release template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/release.md
+++ b/.github/PULL_REQUEST_TEMPLATE/release.md
@@ -1,0 +1,27 @@
+# Release Description
+<!--- Summarize what is being released.  -->
+
+## Milestone
+<!--- Link to the milestone for the release. ---> 
+<!--- Make sure all relevant issues/PRs are included on the linked pages. --->
+Milestone: 
+
+# Release Checklist
+<!--- Fill out the following Release checklist -->
+- [ ] Version number has been updated
+- [ ] Description file updated with New Developers (if applicable)
+- [ ] NEWS.md has been updated and issues linked where appropriate
+- [ ] Ensure all unit tests are passing and Test Coverage is Green on Readme
+- [ ] Ensure CMD Checks are passing on Readme
+- [ ] GitHub actions on this PR are all passing
+- [ ] Draft GitHub release created using automatic template and updated with additional details. Remember to click "release" after PR is merged.
+
+# Clean up Checklist
+<!--- Fill out the following Clean up checklist -->
+- [ ] Delete branches that are stale or abandoned 
+- [ ] Delete branches from merged Pull Requests that made it into `devel`
+- [ ] Triage and close issues that were not closed properly via PRs that made it into release 
+- [ ] Close Pull Requests that are stale 
+- [ ] Set up 0.8.0 News/Changelog Skeleton
+- [ ] Retire labels specific to a time-period (testing feedback) if no longer in use
+- [ ] Remove Inactive Users from Repository

--- a/.github/PULL_REQUEST_TEMPLATE/release.md
+++ b/.github/PULL_REQUEST_TEMPLATE/release.md
@@ -1,11 +1,6 @@
 # Release Description
 <!--- Summarize what is being released.  -->
 
-## Milestone
-<!--- Link to the milestone for the release. ---> 
-<!--- Make sure all relevant issues/PRs are included on the linked pages. --->
-Milestone: 
-
 # Release Checklist
 <!--- Fill out the following Release checklist -->
 - [ ] Version number has been updated

--- a/.github/PULL_REQUEST_TEMPLATE/release.md
+++ b/.github/PULL_REQUEST_TEMPLATE/release.md
@@ -15,6 +15,7 @@ Milestone:
 - [ ] Ensure CMD Checks are passing on Readme
 - [ ] GitHub actions on this PR are all passing
 - [ ] Draft GitHub release created using automatic template and updated with additional details. Remember to click "release" after PR is merged.
+- [ ] Prepare and Post announcements for Linked-In and Slack Channels for Release
 
 # Clean up Checklist
 <!--- Fill out the following Clean up checklist -->


### PR DESCRIPTION
I would like to experiment with this Release template, which would only be used for devel into main PR.  Only thing is...I have never done this so was hoping to experiment...might be a little troubleshooting.  We have something similar in timber package and it works.

Got some loose ideas for Tasks related to the Release and General clean up tasks.  Do you all have any others you would like to see or ones that need more clarification?  

Also unsure on how we do a CRAN release so might need additional insights here.

Guess I'm relying on @thomas-neitmann, @bundfussr and @rossfarrugia for insights and review.  

