### PR TITLE
Cov badge on README is not rendered properly on `devel`

### DIFF
--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -151,7 +151,7 @@ jobs:
       id: badge
       with:
         label: 'Test Coverage'
-        status: "${{ needs.coverage.outputs.coverage-percent }}%"
+        status: "${{ needs.coverage.outputs.coverage-percent }} %"
         color: ${{
           needs.coverage.outputs.coverage-percent > 90 && 'green'              ||
           needs.coverage.outputs.coverage-percent > 80 && 'yellow,green'       ||


### PR DESCRIPTION
Adding a whitespace might fix it