### PR TITLE
Remove duplicate step from link checker workflow

### DIFF
--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -52,25 +52,3 @@ jobs:
             **/*.yml
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Check URLs in docs 🔬
-        uses: lycheeverse/lychee-action@v1.5.0
-        with:
-          fail: true
-          jobSummary: true
-          format: markdown
-          output: links-results.md
-          args: >-
-            --exclude-private
-            --exclude "https://github.com.*.git|lycheeverse.*"
-            --verbose
-            --no-progress
-            ${{ inputs.additional_args }}
-            **/*.md
-            **/*.html
-            **/*.Rmd
-            **/*.yaml
-            **/*.yml
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-


### PR DESCRIPTION
Not sure how it ended up there.