### PR TITLE
Add multiversion docs to main, fix linter workflow

### DIFF
--- a/.github/workflows/lintr.yaml
+++ b/.github/workflows/lintr.yaml
@@ -16,7 +16,6 @@ name: lint
 
 jobs:
   lint:
-    name: lint
     runs-on: ubuntu-20.04
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
@@ -52,7 +51,10 @@ jobs:
 
       - name: Install dependencies
         run: |
-          if(file.exists("renv.lock")) renv::install("lintr")
+          if(file.exists("renv.lock")) {
+            install.packages("renv")
+            renv::install("lintr")
+          }
         shell: Rscript {0}
 
       - name: Lint

--- a/.github/workflows/lintr.yaml
+++ b/.github/workflows/lintr.yaml
@@ -12,11 +12,11 @@ on:
       - devel
       - pre-release
 
-name: Lint
+name: lint
 
 jobs:
   lint:
-    name: Lint
+    name: lint
     runs-on: ubuntu-20.04
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/lintr.yaml
+++ b/.github/workflows/lintr.yaml
@@ -1,18 +1,22 @@
 on:
   workflow_dispatch:
+  workflow_call:
   push:
     branches:
       - main
       - devel
+      - pre-release
   pull_request:
     branches:
       - main
       - devel
+      - pre-release
 
-name: lint
+name: Lint
 
 jobs:
   lint:
+    name: Lint
     runs-on: ubuntu-20.04
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
@@ -48,17 +52,12 @@ jobs:
 
       - name: Install dependencies
         run: |
-          if (!requireNamespace("renv", quietly = TRUE)) install.packages("renv")
-          renv::restore()
-          renv::install("lintr")
+          if(file.exists("renv.lock")) renv::install("lintr")
         shell: Rscript {0}
-
-      - name: Install package
-        run: R CMD INSTALL .
 
       - name: Lint
         run: |
-          (lints <- lintr::lint_package())
+          lints <- lintr::lint_package()
           saveRDS(lints, file = "lints.rds")
         shell: Rscript {0}
 

--- a/.github/workflows/lintr.yaml
+++ b/.github/workflows/lintr.yaml
@@ -60,6 +60,7 @@ jobs:
       - name: Lint
         run: |
           lints <- lintr::lint_package()
+          cat(lints)
           saveRDS(lints, file = "lints.rds")
         shell: Rscript {0}
 

--- a/.github/workflows/pkgdown.yml
+++ b/.github/workflows/pkgdown.yml
@@ -1,8 +1,11 @@
 on:
   workflow_dispatch:
+  workflow_call:
   push:
     branches:
       - main
+      - devel
+      - pre-release
 
 name: pkgdown
 
@@ -55,4 +58,31 @@ jobs:
         run: |
           git config --local user.email "actions@github.com"
           git config --local user.name "GitHub Actions"
-          Rscript -e 'pkgdown::deploy_to_branch(new_process = FALSE)'
+          BRANCH_OR_TAG="${GITHUB_REF##*/}"
+          Rscript - <<EOF
+          pkgdown::deploy_to_branch(
+            new_process = FALSE,
+            subdir = "${BRANCH_OR_TAG}",
+            clean = TRUE
+          )
+          EOF
+
+  multi-version-docs:
+    name: Multi-version docs 📑
+    needs: pkgdown
+    runs-on: ubuntu-20.04
+    if: >
+      github.event_name == 'push'
+        && !contains(github.event.commits[0].message, '[skip docs]')
+    steps:
+      - name: Checkout repo 🛎
+        uses: actions/checkout@v3
+        with:
+          path: ${{ github.event.repository.name }}
+          ref: "gh-pages"
+
+      - name: Create and publish docs ↗️
+        uses: insightsengineering/r-pkgdown-multiversion@v2
+        with:
+          path: ${{ github.event.repository.name }}
+          default-landing-page: "main"


### PR DESCRIPTION
This is needed on main as well, immediately if possible to make it work as `main` is the intended default landing page.
This will fix the 404 on the admiral website.

Also fix the seemingly broken linter workflow.