### PR TITLE
Build and publish docs only on main

### DIFF
--- a/.github/workflows/common.yml
+++ b/.github/workflows/common.yml
@@ -69,7 +69,9 @@ jobs:
   docs:
     name: Documentation
     uses: pharmaverse/admiralci/.github/workflows/pkgdown.yml@main
-    if: github.event_name == 'push'
+    # Only run this for main
+    # Change this after the next release to remove the ref condition
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     with:
       r-version: $R_VERSION
       # Whether to skip multiversion docs


### PR DESCRIPTION
This way we don't push doc updates from devel to gh-pages on every merge to devel.
