### PR TITLE
Drop names in `if_else()`

### DIFF
--- a/R/derive_date_vars.R
+++ b/R/derive_date_vars.R
@@ -1178,7 +1178,7 @@ compute_tmf <- function(dtc,
     minute = "M",
     second = "S"
   )
-  flag <- if_else(is.na(dtm) | is.na(highest_miss), NA_character_, map[highest_miss])
+  flag <- if_else(is.na(dtm) | is.na(highest_miss), NA_character_, unname(map[highest_miss]))
 
   if (ignore_seconds_flag) {
     if (any(!is.na(partial[["second"]]))) {


### PR DESCRIPTION
This PR makes your package compatible with the next version of dplyr:

`if_else()` now preserves names from `true` and `false`, but it seems like you don't actually expect this so I've unnamed early.

We plan to submit dplyr 1.1.0 on January 27th.

This should be compatible with both dev and CRAN dplyr. It would help us out if you could go ahead and send a patch version of your package to CRAN ahead of time! Thanks!