### PR TITLE
Closes wrong pull requests

### DIFF
--- a/R/derive_vars_dy.R
+++ b/R/derive_vars_dy.R
@@ -102,31 +102,20 @@ derive_vars_dy <- function(dataset,
     abort(err_msg)
   }
 
-  dy_vars <- if_else(
+  # named vector passed to `.names` in `across()` to derive name of dy_vars
+  dy_vars <- set_names(if_else(
     source_names == "",
     str_replace_all(vars2chr(source_vars), "(DT|DTM)$", "DY"),
     source_names
-  )
+  ), vars2chr(source_vars))
+
   warn_if_vars_exist(dataset, dy_vars)
 
-  if (n_vars > 1L) {
-    dataset %>%
-      mutate(
-        across(
-          .cols = vars2chr(unname(source_vars)),
-          .fns = list(temp = ~
-            compute_duration(start_date = !!reference_date, end_date = .))
-        )
-      ) %>%
-      rename_with(
-        .cols = ends_with("temp"),
-        .fn = ~dy_vars
-      )
-  } else {
-    dataset %>%
-      mutate(
-        !!sym(dy_vars) :=
-          compute_duration(start_date = !!reference_date, end_date = !!source_vars[[1]])
-      )
-  }
+  dataset %>%
+    mutate(
+      across(
+        .cols = vars2chr(unname(source_vars)),
+        .fns = ~compute_duration(start_date = !!reference_date, end_date = .x),
+        .names = "{dy_vars}"
+      ))
 }

--- a/R/derive_vars_dy.R
+++ b/R/derive_vars_dy.R
@@ -115,7 +115,8 @@ derive_vars_dy <- function(dataset,
     mutate(
       across(
         .cols = vars2chr(unname(source_vars)),
-        .fns = ~compute_duration(start_date = !!reference_date, end_date = .x),
+        .fns = ~ compute_duration(start_date = !!reference_date, end_date = .x),
         .names = "{dy_vars}"
-      ))
+      )
+    )
 }

--- a/tests/testthat/test-derive_vars_dy.R
+++ b/tests/testthat/test-derive_vars_dy.R
@@ -285,3 +285,35 @@ test_that("derive_vars_dy Test 9: Single named --DT input when ref date is --DTM
     keys = c("STUDYID", "USUBJID")
   )
 })
+
+## Test 10: no error if input with variable end with `_temp` ----
+test_that("derive_vars_dy Test 10: no error if input with variable end with `_temp`", {
+  datain <- tibble::tribble(
+    ~STUDYID, ~USUBJID, ~TRTSDTM, ~ASTDT, ~test_temp,
+    "TEST01", "PAT01", "2014-01-17T23:59:59", "2014-01-18", "test"
+  ) %>%
+    mutate(
+      TRTSDTM = lubridate::as_datetime(TRTSDTM),
+      ASTDT = lubridate::ymd(ASTDT)
+    )
+
+  expected_output <- tibble::tribble(
+    ~STUDYID, ~USUBJID, ~TRTSDTM, ~ASTDT,  ~test_temp, ~ASTDY,
+    "TEST01", "PAT01", "2014-01-17T23:59:59", "2014-01-18", "test", 2
+  ) %>%
+    mutate(
+      TRTSDTM = lubridate::as_datetime(TRTSDTM),
+      ASTDT = lubridate::ymd(ASTDT)
+    )
+
+  actual_output <- derive_vars_dy(datain,
+                                  reference_date = TRTSDTM,
+                                  source_vars = exprs(ASTDT)
+  )
+
+  expect_dfs_equal(
+    expected_output,
+    actual_output,
+    keys = c("STUDYID", "USUBJID")
+  )
+})


### PR DESCRIPTION
Thank you for your Pull Request! We have developed this task checklist from the [Development Process Guide](https://pharmaverse.github.io/admiraldev/devel/articles/development_process.html) to help with the final steps of the process. Completing the below tasks helps to ensure our reviewers can maximize their time on your code as well as making sure the admiral codebase remains robust and consistent.   

Please check off each taskbox as an acknowledgment that you completed the task or check off that it is not relevant to your Pull Request. This checklist is part of the Github Action workflows and the Pull Request will not be merged into the `devel` branch until you have checked off each task.

- [x] Place Closes #<insert_issue_number> into the beginning of your Pull Request Title (Use Edit button in top-right if you need to update)
- [x] Code is formatted according to the [tidyverse style guide](https://style.tidyverse.org/). Run `styler::style_file()` to style R and Rmd files
- [x] Updated relevant unit tests or have written new unit tests, which should consider realistic data scenarios and edge cases, e.g. empty datasets, errors, boundary cases etc. - See [Unit Test Guide](https://pharmaverse.github.io/admiraldev/devel/articles/unit_test_guidance.html#tests-should-be-robust-to-cover-realistic-data-scenarios)
- [x] If you removed/replaced any function and/or function parameters, did you fully follow the [deprecation guidance](https://pharmaverse.github.io/admiraldev/devel/articles/programming_strategy.html#deprecation)? 
- [x] Update to all relevant roxygen headers and examples, including keywords and families. Refer to the [categorization of functions](https://pharmaverse.github.io/admiraldev/devel/articles/programming_strategy.html#categorization-of-functions) to tag appropriate keyword/family.
- [x] Run `devtools::document()` so all `.Rd` files in the `man` folder and the `NAMESPACE` file in the project root are updated appropriately
- [x] Address any updates needed for vignettes and/or templates
- [x] Update `NEWS.md` if the changes pertain to a user-facing function (i.e. it has an `@export` tag) or documentation aimed at users (rather than developers)
- [ ] Build admiral site `pkgdown::build_site()` and check that all affected examples are displayed correctly and that all new functions occur on the "[Reference](https://pharmaverse.github.io/admiral/cran-release/reference/index.html)" page. 
- [ ] Address or fix all lintr warnings and errors - `lintr::lint_package()`
- [x] Run `R CMD check` locally and address all errors and warnings - `devtools::check()`
- [x] Link the issue in the Development Section on the right hand side.
- [x] Address all merge conflicts and resolve appropriately
- [ ] Pat yourself on the back for a job well done! Much love to your accomplishment!

The updates were done by passing the named vector of `dy_vars`  to `.names` in `across()` and it will not create the temporary variables end with `_temp`.

A related test that the input dataset has a variable end with `_temp` was created and no error occurred.

The updates had no impact on user facing and I ticked the some of check list that may be not applicable.

For `pkgdown::build_site()`, I got the below errors, but I am not sure if it was related to this updates.
![image](https://github.com/pharmaverse/admiral/assets/98389771/193f9b19-6018-441f-add3-8d6d5bb70967)
![image](https://github.com/pharmaverse/admiral/assets/98389771/41d5d579-cf1c-4ff8-a2ab-da3ceafa37bc)

For 'lintr::lint_package()', the following message is from the previous commit, and I am not familiar with `lintr` and wonder if this is a problem.
![image](https://github.com/pharmaverse/admiral/assets/98389771/bb7f8a3a-4283-41ce-b096-145e682a6b35)


