### PR TITLE
Add secret for `gert`'s date fetcher

### DIFF
--- a/.github/workflows/common.yml
+++ b/.github/workflows/common.yml
@@ -71,6 +71,8 @@ jobs:
     with:
       r-version: "4.3"
       skip-multiversion-docs: true
+    secrets:
+      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
   linter:
     name: Lint
     uses: pharmaverse/admiralci/.github/workflows/lintr.yml@main


### PR DESCRIPTION
`gert` is used for the articles that has the package version links. It needs a GitHub PAT to get release dates from the GitHub releases API.