### PR TITLE
[skip vbump] Revert version in NEWS.md

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
-# admiral 0.12.3.9006 version)
+# admiral (development version)
 
 ## New Features
 


### PR DESCRIPTION
Notice how I've added `[skip vbump]` to the PR title. This will skip a version update on the `main` branch.