### PR TITLE
Addresses reverse dep check for get_joined_sub_data(...) using left_join(..., relationship = "many-to-many" )

### DIFF
--- a/R/derive_joined.R
+++ b/R/derive_joined.R
@@ -908,7 +908,8 @@ get_joined_sub_data <- function(dataset,
       dataset,
       dataset_add,
       by = vars2chr(by_vars),
-      suffix = c("", ".join")
+      suffix = c("", ".join"),
+      relationship = "many-to-many"
     )
 
   if (join_type != "all") {


### PR DESCRIPTION
This fixes warnings with a version of dplyr that seems to warn more aggressively. I wonder why plain dplyr doesn't trigger a warning here.

Wild guess: could this function be made more efficient with dplyr's new rolling joins?

- [ ] Place Closes #<insert_issue_number> into the beginning of your Pull Request Title (Use Edit button in top-right if you need to update)
- [x] Code is formatted according to the [tidyverse style guide](https://style.tidyverse.org/). Run `styler::style_file()` to style R and Rmd files
- [ ] Updated relevant unit tests or have written new unit tests, which should consider realistic data scenarios and edge cases, e.g. empty datasets, errors, boundary cases etc. - See [Unit Test Guide](https://pharmaverse.github.io/admiraldev/articles/unit_test_guidance.html#tests-should-be-robust-to-cover-realistic-data-scenarios)
- [x] If you removed/replaced any function and/or function parameters, did you fully follow the [deprecation guidance](https://pharmaverse.github.io/admiraldev/articles/programming_strategy.html#deprecation)?
- [ ] Review the [Cheat Sheet](https://github.com/pharmaverse/admiral/blob/main/inst/cheatsheet/admiral_cheatsheet.pdf). Make any required updates to it by editing the file `inst/cheatsheet/admiral_cheatsheet.pptx` and re-upload a PDF and a PNG version of it to the same folder. (The PNG version can be created by taking a screenshot of the PDF version.)
- [ ] Update to all relevant roxygen headers and examples, including keywords and families. Refer to the [categorization of functions](https://pharmaverse.github.io/admiraldev/articles/programming_strategy.html#categorization-of-functions) to tag appropriate keyword/family.
- [ ] Run `devtools::document()` so all `.Rd` files in the `man` folder and the `NAMESPACE` file in the project root are updated appropriately
- [ ] Address any updates needed for vignettes and/or templates
- [ ] Update `NEWS.md` under the header `# admiral (development version)` if the changes pertain to a user-facing function (i.e. it has an `@export` tag) or documentation aimed at users (rather than developers). A Developer Notes section is available in `NEWS.md` for tracking developer-facing issues.  
- [ ] Build admiral site `pkgdown::build_site()` and check that all affected examples are displayed correctly and that all new functions occur on the "[Reference](https://pharmaverse.github.io/admiral/reference/index.html)" page. 
- [ ] Address or fix all lintr warnings and errors - `lintr::lint_package()`
- [ ] Run `R CMD check` locally and address all errors and warnings - `devtools::check()`
- [ ] Link the issue in the Development Section on the right hand side.
- [ ] Address all merge conflicts and resolve appropriately
- [ ] Pat yourself on the back for a job well done! Much love to your accomplishment!
