### PR TITLE
fix: Re-enable search index generation

### DIFF
--- a/man/derive_extreme_records.Rd
+++ b/man/derive_extreme_records.Rd
@@ -415,17 +415,14 @@ derive_extreme_records(
 #>   <chr>   <chr>   <dbl>
 #> 1 1       MINIMUM   123
 #> 2 2       MINIMUM    93
-#> Warning: Dataset contains duplicate records with respect to
-#> `USUBJID` and `AVAL`
-#> i Run `admiral::get_duplicates_dataset()` to access
-#>   the duplicate records}\if{html}{\out{</div>}}
+#> Warning: Dataset contains duplicate records with respect to `USUBJID` and `AVAL`
+#> i Run `admiral::get_duplicates_dataset()` to access the duplicate records}\if{html}{\out{</div>}}
 
 For investigating the issue, the dataset of the duplicate source records
 can be obtained by calling \code{get_duplicates_dataset()}:
 
 \if{html}{\out{<div class="sourceCode r">}}\preformatted{get_duplicates_dataset()
-#> Duplicate records with respect to `USUBJID` and
-#> `AVAL`.
+#> Duplicate records with respect to `USUBJID` and `AVAL`.
 #> # A tibble: 2 × 3
 #>   USUBJID  AVAL AVISIT
 #> * <chr>   <dbl> <chr> 

--- a/man/derive_param_tte.Rd
+++ b/man/derive_param_tte.Rd
@@ -349,17 +349,15 @@ derive_param_tte(
 #> 3 02      AB42    END OF STUDY ADSL   EOSDT      NA     1 2021-02-03 2021-01-16
 #> 4 02      AB42    END OF STUDY ADSL   EOSDT      NA     1 2021-02-03 2021-01-16
 #> # i 2 more variables: PARAMCD <chr>, PARAM <chr>
-#> Warning: Dataset "adae" contains duplicate records with respect
-#> to `STUDYID`, `USUBJID`, `AEDECOD`, and `ASTDT`
-#> i Run `admiral::get_duplicates_dataset()` to access
-#>   the duplicate records}\if{html}{\out{</div>}}
+#> Warning: Dataset "adae" contains duplicate records with respect to `STUDYID`, `USUBJID`,
+#> `AEDECOD`, and `ASTDT`
+#> i Run `admiral::get_duplicates_dataset()` to access the duplicate records}\if{html}{\out{</div>}}
 
 For investigating the issue, the dataset of the duplicate source records
 can be obtained by calling \code{get_duplicates_dataset()}:
 
 \if{html}{\out{<div class="sourceCode r">}}\preformatted{get_duplicates_dataset()
-#> Duplicate records with respect to `STUDYID`,
-#> `USUBJID`, `AEDECOD`, and `ASTDT`.
+#> Duplicate records with respect to `STUDYID`, `USUBJID`, `AEDECOD`, and `ASTDT`.
 #> # A tibble: 2 × 6
 #>   STUDYID USUBJID AEDECOD ASTDT      AESEQ AESER
 #> * <chr>   <chr>   <chr>   <date>     <dbl> <chr>

--- a/man/derive_var_joined_exist_flag.Rd
+++ b/man/derive_var_joined_exist_flag.Rd
@@ -819,22 +819,19 @@ derive_var_joined_exist_flag(
 #> 5 2             1     1 Y     Y     
 #> 6 2             2     8 Y     <NA>  
 #> 7 2             2    10 Y     <NA>  
-#> Warning: Dataset `dataset` contains duplicate records with
-#> respect to `USUBJID` and `AVISITN`
-#> i Run `admiral::get_duplicates_dataset()` to access
-#>   the duplicate records
-#> Warning: Dataset `dataset_add` contains duplicate records with
-#> respect to `USUBJID` and `AVISITN`
-#> i Run `admiral::get_duplicates_dataset()` to access
-#>   the duplicate records}\if{html}{\out{</div>}}
+#> Warning: Dataset `dataset` contains duplicate records with respect to `USUBJID` and
+#> `AVISITN`
+#> i Run `admiral::get_duplicates_dataset()` to access the duplicate records
+#> Warning: Dataset `dataset_add` contains duplicate records with respect to `USUBJID` and
+#> `AVISITN`
+#> i Run `admiral::get_duplicates_dataset()` to access the duplicate records}\if{html}{\out{</div>}}
 
 The records for \code{USUBJID == "2"} are not unique with respect to
 \code{USUBJID} and \code{AVISITN}. Thus a warning is issued. The duplicates can be
 accessed by calling \code{get_duplicates_dataset()}:
 
 \if{html}{\out{<div class="sourceCode r">}}\preformatted{get_duplicates_dataset()
-#> Duplicate records with respect to `USUBJID` and
-#> `AVISITN`.
+#> Duplicate records with respect to `USUBJID` and `AVISITN`.
 #> # A tibble: 2 × 4
 #>   USUBJID AVISITN   ADY AVALC
 #> * <chr>     <dbl> <dbl> <chr>

--- a/man/derive_vars_merged.Rd
+++ b/man/derive_vars_merged.Rd
@@ -378,17 +378,16 @@ derive_vars_merged(
 #> 1 01         61 YEARS  82.6
 #> 2 02         64 YEARS  NA  
 #> 3 03         85 YEARS  NA  
-#> Warning: Dataset contains duplicate records with respect to
-#> `STUDYID`, `USUBJID`, and `convert_dtc_to_dtm(VSDTC)`
-#> i Run `admiral::get_duplicates_dataset()` to access
-#>   the duplicate records}\if{html}{\out{</div>}}
+#> Warning: Dataset contains duplicate records with respect to `STUDYID`, `USUBJID`, and
+#> `convert_dtc_to_dtm(VSDTC)`
+#> i Run `admiral::get_duplicates_dataset()` to access the duplicate records}\if{html}{\out{</div>}}
 
 For investigating the issue, the dataset of the duplicate source records
 can be obtained by calling \code{get_duplicates_dataset()}:
 
 \if{html}{\out{<div class="sourceCode r">}}\preformatted{get_duplicates_dataset()
-#> Duplicate records with respect to `STUDYID`,
-#> `USUBJID`, and `convert_dtc_to_dtm(VSDTC)`.
+#> Duplicate records with respect to `STUDYID`, `USUBJID`, and
+#> `convert_dtc_to_dtm(VSDTC)`.
 #> # A tibble: 2 × 9
 #>   STUDYID USUBJID convert_dtc_to_dtm(VSDT…¹ DOMAIN VSTESTCD VISIT VSSTRESN VSDTC
 #> * <chr>   <chr>   <dttm>                    <chr>  <chr>    <chr>    <dbl> <chr>
@@ -495,8 +494,8 @@ ex_ext <- derive_vars_dtm(
   new_vars_prefix = "EXST",
   highest_imputation = "M"
 )
-#> The default value of `ignore_seconds_flag` will change
-#> to "TRUE" in admiral 1.4.0.
+#> The default value of `ignore_seconds_flag` will change to "TRUE" in admiral
+#> 1.4.0.
 
 derive_vars_merged(
   dm,


### PR DESCRIPTION
This fixes the search index generation, which was broken due to:

1. Incorrect URLs in DESCRIPTION:
![Screenshot 2025-06-30 at 9 07 27 AM](https://github.com/user-attachments/assets/d608e0c6-8827-4ef0-aa8c-077e34883159)

1. Enabling `development.mode`
