### PR TITLE
Closes #3135: clarify derive_expected_records() dataset_ref docs

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -8,6 +8,11 @@
 
 ## Documentation
 
+- The documentation of `derive_expected_records()` was clarified to state that
+`dataset_ref` should contain only the variables that define the expected
+observations, as any additional variable becomes part of the matching key and
+can lead to more records being created than intended. (#3135)
+
 ## Various
 
 <details>

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,10 +4,10 @@
 
 ## Updates of Existing Functions
 
-- `derive_expected_records()` now prints a message reporting the variables used
-to identify the expected observations and the number of records added, so an
-unintended extra variable in `dataset_ref` becomes visible. The message can be
-silenced with `suppressMessages()`. (#3135)
+- `derive_expected_records()` now reports the variables used to identify the
+expected observations (derived from `dataset_ref`), so an unintended extra
+variable in `dataset_ref` becomes visible. The message can be suppressed with
+the new `quiet` argument. (#3135)
 
 ## Breaking Changes
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,11 @@
 
 ## Updates of Existing Functions
 
+- `derive_expected_records()` now prints a message reporting the variables used
+to identify the expected observations and the number of records added, so an
+unintended extra variable in `dataset_ref` becomes visible. The message can be
+silenced with `suppressMessages()`. (#3135)
+
 ## Breaking Changes
 
 ## Documentation

--- a/R/derive_expected_records.R
+++ b/R/derive_expected_records.R
@@ -37,6 +37,14 @@
 #'   symbol, a numeric value, `NA`, or expressions, e.g., `exprs(PARAMCD =
 #'   "TDOSE", PARCAT1 = "OVERALL")`.
 #'
+#' @param quiet Suppress the message?
+#'
+#'   The variables used to identify the expected observations are derived from
+#'   `dataset_ref` rather than stated explicitly in the function call. By default
+#'   a message reports them. Set `quiet = TRUE` to suppress this message.
+#'
+#'   *Permitted values*: `TRUE`, `FALSE`
+#'
 #' @details For each group (the variables specified in the `by_vars` parameter),
 #' those records from `dataset_ref` that are missing in the input
 #' dataset are added to the output dataset.
@@ -49,10 +57,9 @@
 #' than intended, as input records that differ only on the extra variable are
 #' no longer recognized as already present.
 #'
-#' At runtime the function reports the variables used to identify the expected
-#' observations and the number of records added, so an unintended extra variable
-#' in `dataset_ref` becomes visible. This message can be silenced with
-#' `suppressMessages()`.
+#' By default the function reports the variables used to identify the expected
+#' observations, as these are derived from `dataset_ref` rather than stated
+#' explicitly in the call. Set `quiet = TRUE` to suppress this message.
 #'
 #' @return The input dataset with the missed expected observations added for each
 #' `by_vars`. Note, a variable will only be populated in the new parameter rows
@@ -106,7 +113,8 @@
 derive_expected_records <- function(dataset,
                                     dataset_ref,
                                     by_vars = NULL,
-                                    set_values_to = NULL) {
+                                    set_values_to = NULL,
+                                    quiet = FALSE) {
   # Check input parameters
   assert_vars(by_vars, optional = TRUE)
   assert_data_frame(dataset_ref)
@@ -115,6 +123,7 @@ derive_expected_records <- function(dataset,
     required_vars = expr_c(by_vars, chr2vars(colnames(dataset_ref)))
   )
   assert_varval_list(set_values_to, optional = TRUE)
+  assert_logical_scalar(quiet)
 
   # Derive expected records
   ## ids: Variables from by_vars but not in dataset_ref
@@ -136,16 +145,9 @@ derive_expected_records <- function(dataset,
     mutate(!!!set_values_to) %>%
     anti_join(dataset %>% select(all_of(exp_obs_vars)), by = c(exp_obs_vars))
 
-  cli_inform(
-    c(
-      "Expected observations identified by {.var {exp_obs_vars}}.",
-      i = "{nrow(new_obs)} new record{?s} added to the input dataset.",
-      i = paste(
-        "If more records were added than expected, check that {.arg dataset_ref}",
-        "contains only the variables that define the expected observations."
-      )
-    )
-  )
+  if (!quiet) {
+    cli_inform("Expected observations identified by {.var {exp_obs_vars}}.")
+  }
 
   # Combine dataset + newly added records
   bind_rows(dataset, new_obs) %>%

--- a/R/derive_expected_records.R
+++ b/R/derive_expected_records.R
@@ -49,6 +49,11 @@
 #' than intended, as input records that differ only on the extra variable are
 #' no longer recognized as already present.
 #'
+#' At runtime the function reports the variables used to identify the expected
+#' observations and the number of records added, so an unintended extra variable
+#' in `dataset_ref` becomes visible. This message can be silenced with
+#' `suppressMessages()`.
+#'
 #' @return The input dataset with the missed expected observations added for each
 #' `by_vars`. Note, a variable will only be populated in the new parameter rows
 #' if it is specified in `by_vars` or `set_values_to`.
@@ -130,6 +135,17 @@ derive_expected_records <- function(dataset,
   new_obs <- exp_obsv %>%
     mutate(!!!set_values_to) %>%
     anti_join(dataset %>% select(all_of(exp_obs_vars)), by = c(exp_obs_vars))
+
+  cli_inform(
+    c(
+      "Expected observations identified by {.var {exp_obs_vars}}.",
+      i = "{nrow(new_obs)} new record{?s} added to the input dataset.",
+      i = paste(
+        "If more records were added than expected, check that {.arg dataset_ref}",
+        "contains only the variables that define the expected observations."
+      )
+    )
+  )
 
   # Combine dataset + newly added records
   bind_rows(dataset, new_obs) %>%

--- a/R/derive_expected_records.R
+++ b/R/derive_expected_records.R
@@ -11,6 +11,13 @@
 #'   Data frame with the expected observations, e.g., all the expected
 #'   combinations of `PARAMCD`, `PARAM`, `AVISIT`, `AVISITN`, ...
 #'
+#'   `dataset_ref` should contain *only* the variables that define the expected
+#'   observations. Every variable in `dataset_ref` is used to match the expected
+#'   observations against the input dataset, so any additional variable becomes
+#'   part of the matching key and can result in more records being created than
+#'   intended (see Details). All variables in `dataset_ref` must also be present
+#'   in `dataset`.
+#'
 #' @param by_vars Grouping variables
 #'
 #'   For each group defined by `by_vars` those observations from `dataset_ref`
@@ -33,6 +40,14 @@
 #' @details For each group (the variables specified in the `by_vars` parameter),
 #' those records from `dataset_ref` that are missing in the input
 #' dataset are added to the output dataset.
+#'
+#' All variables in `dataset_ref` are used to identify the expected observations
+#' and to match them against the input dataset. For this reason `dataset_ref`
+#' should contain only the variables that define the expected observations
+#' (e.g. the visit and/or parameter variables). Including any additional
+#' variable extends the matching key and can lead to more records being added
+#' than intended, as input records that differ only on the extra variable are
+#' no longer recognized as already present.
 #'
 #' @return The input dataset with the missed expected observations added for each
 #' `by_vars`. Note, a variable will only be populated in the new parameter rows

--- a/man/derive_expected_records.Rd
+++ b/man/derive_expected_records.Rd
@@ -25,6 +25,13 @@ The variables specified by the \code{dataset_ref} and \code{by_vars} arguments a
 Data frame with the expected observations, e.g., all the expected
 combinations of \code{PARAMCD}, \code{PARAM}, \code{AVISIT}, \code{AVISITN}, ...
 
+\code{dataset_ref} should contain \emph{only} the variables that define the expected
+observations. Every variable in \code{dataset_ref} is used to match the expected
+observations against the input dataset, so any additional variable becomes
+part of the matching key and can result in more records being created than
+intended (see Details). All variables in \code{dataset_ref} must also be present
+in \code{dataset}.
+
 \describe{
 \item{Default value}{none}
 }}
@@ -68,6 +75,14 @@ contains missing observations.
 For each group (the variables specified in the \code{by_vars} parameter),
 those records from \code{dataset_ref} that are missing in the input
 dataset are added to the output dataset.
+
+All variables in \code{dataset_ref} are used to identify the expected observations
+and to match them against the input dataset. For this reason \code{dataset_ref}
+should contain only the variables that define the expected observations
+(e.g. the visit and/or parameter variables). Including any additional
+variable extends the matching key and can lead to more records being added
+than intended, as input records that differ only on the extra variable are
+no longer recognized as already present.
 }
 \examples{
 library(tibble)

--- a/man/derive_expected_records.Rd
+++ b/man/derive_expected_records.Rd
@@ -83,6 +83,11 @@ should contain only the variables that define the expected observations
 variable extends the matching key and can lead to more records being added
 than intended, as input records that differ only on the extra variable are
 no longer recognized as already present.
+
+At runtime the function reports the variables used to identify the expected
+observations and the number of records added, so an unintended extra variable
+in \code{dataset_ref} becomes visible. This message can be silenced with
+\code{suppressMessages()}.
 }
 \examples{
 library(tibble)

--- a/man/derive_expected_records.Rd
+++ b/man/derive_expected_records.Rd
@@ -8,7 +8,8 @@ derive_expected_records(
   dataset,
   dataset_ref,
   by_vars = NULL,
-  set_values_to = NULL
+  set_values_to = NULL,
+  quiet = FALSE
 )
 }
 \arguments{
@@ -61,6 +62,18 @@ symbol, a numeric value, \code{NA}, or expressions, e.g., \code{exprs(PARAMCD = 
 \describe{
 \item{Default value}{\code{NULL}}
 }}
+
+\item{quiet}{Suppress the message?
+
+The variables used to identify the expected observations are derived from
+\code{dataset_ref} rather than stated explicitly in the function call. By default
+a message reports them. Set \code{quiet = TRUE} to suppress this message.
+
+\emph{Permitted values}: \code{TRUE}, \code{FALSE}
+
+\describe{
+\item{Default value}{\code{FALSE}}
+}}
 }
 \value{
 The input dataset with the missed expected observations added for each
@@ -84,10 +97,9 @@ variable extends the matching key and can lead to more records being added
 than intended, as input records that differ only on the extra variable are
 no longer recognized as already present.
 
-At runtime the function reports the variables used to identify the expected
-observations and the number of records added, so an unintended extra variable
-in \code{dataset_ref} becomes visible. This message can be silenced with
-\code{suppressMessages()}.
+By default the function reports the variables used to identify the expected
+observations, as these are derived from \code{dataset_ref} rather than stated
+explicitly in the call. Set \code{quiet = TRUE} to suppress this message.
 }
 \examples{
 library(tibble)

--- a/tests/testthat/test-derive_expected_records.R
+++ b/tests/testthat/test-derive_expected_records.R
@@ -170,8 +170,8 @@ test_that("derive_expected_records Test 4: visit variables are parameter depende
 })
 
 
-## Test 5: message reports matching variables and records added ----
-test_that("derive_expected_records Test 5: message reports matching variables and records added", {
+## Test 5: message reports matching variables, suppressed by `quiet` ----
+test_that("derive_expected_records Test 5: message reports matching variables, suppressed by `quiet`", {
   input <- tibble::tribble(
     ~USUBJID, ~PARAMCD, ~AVISITN, ~AVISIT, ~AVAL,
     "1", "a", 1, "WEEK 1", 10,
@@ -186,6 +186,7 @@ test_that("derive_expected_records Test 5: message reports matching variables an
     "b", 2, "WEEK 2"
   )
 
+  # message issued by default
   expect_message(
     derive_expected_records(
       dataset = input,
@@ -194,5 +195,16 @@ test_that("derive_expected_records Test 5: message reports matching variables an
       set_values_to = exprs(DTYPE = "DERIVED")
     ),
     "Expected observations identified"
+  )
+
+  # message suppressed when `quiet = TRUE`
+  expect_no_message(
+    derive_expected_records(
+      dataset = input,
+      dataset_ref = expected_obsv,
+      by_vars = NULL,
+      set_values_to = exprs(DTYPE = "DERIVED"),
+      quiet = TRUE
+    )
   )
 })

--- a/tests/testthat/test-derive_expected_records.R
+++ b/tests/testthat/test-derive_expected_records.R
@@ -28,12 +28,12 @@ test_that("derive_expected_records Test 1: missing values in `by_vars`", {
       mutate(DTYPE = "DERIVED")
   )
 
-  actual_output <- derive_expected_records(
+  actual_output <- suppressMessages(derive_expected_records(
     dataset = input,
     dataset_ref = expected_obsv,
     by_vars = exprs(USUBJID),
     set_values_to = exprs(DTYPE = "DERIVED")
-  )
+  ))
 
   expect_dfs_equal(
     base = expected_output,
@@ -69,12 +69,12 @@ test_that("derive_expected_records Test 2: `by_vars` = NULL", {
       mutate(DTYPE = "DERIVED")
   )
 
-  actual_output <- derive_expected_records(
+  actual_output <- suppressMessages(derive_expected_records(
     dataset = input,
     dataset_ref = expected_obsv,
     by_vars = NULL,
     set_values_to = exprs(DTYPE = "DERIVED")
-  )
+  ))
 
   expect_dfs_equal(
     base = expected_output,
@@ -112,12 +112,12 @@ test_that("derive_expected_records Test 3: visit variables are parameter indepen
       mutate(DTYPE = "DERIVED")
   )
 
-  actual_output <- derive_expected_records(
+  actual_output <- suppressMessages(derive_expected_records(
     dataset = input,
     dataset_ref = expected_obsv,
     by_vars = exprs(USUBJID, PARAMCD),
     set_values_to = exprs(DTYPE = "DERIVED")
-  )
+  ))
 
   expect_dfs_equal(
     base = expected_output,
@@ -155,16 +155,44 @@ test_that("derive_expected_records Test 4: visit variables are parameter depende
       mutate(DTYPE = "DERIVED")
   )
 
-  actual_output <- derive_expected_records(
+  actual_output <- suppressMessages(derive_expected_records(
     dataset = input,
     dataset_ref = expected_obsv,
     by_vars = exprs(USUBJID),
     set_values_to = exprs(DTYPE = "DERIVED")
-  )
+  ))
 
   expect_dfs_equal(
     base = expected_output,
     compare = actual_output,
     keys = c("USUBJID", "PARAMCD", "AVISITN", "AVISIT", "DTYPE")
+  )
+})
+
+
+## Test 5: message reports matching variables and records added ----
+test_that("derive_expected_records Test 5: message reports matching variables and records added", {
+  input <- tibble::tribble(
+    ~USUBJID, ~PARAMCD, ~AVISITN, ~AVISIT, ~AVAL,
+    "1", "a", 1, "WEEK 1", 10,
+    "1", "b", 2, "WEEK 2", 11
+  )
+
+  expected_obsv <- tibble::tribble(
+    ~PARAMCD, ~AVISITN, ~AVISIT,
+    "a", 1, "WEEK 1",
+    "a", 2, "WEEK 2",
+    "b", 1, "WEEK 1",
+    "b", 2, "WEEK 2"
+  )
+
+  expect_message(
+    derive_expected_records(
+      dataset = input,
+      dataset_ref = expected_obsv,
+      by_vars = NULL,
+      set_values_to = exprs(DTYPE = "DERIVED")
+    ),
+    "Expected observations identified"
   )
 })


### PR DESCRIPTION
Closes #3135 as agreed in the issue thread (docs-only scope per @manciniedoardo).

Clarifies in the `dataset_ref` param description and Details section of
`derive_expected_records()` that `dataset_ref` should contain only the
variables defining the expected observations, since every variable in it
becomes part of the matching key — extra variables can silently inflate
the derived records.

---

Thank you for your Pull Request! We have developed this task checklist from the [Development Process Guide](https://pharmaverse.github.io/admiral/cran-release/CONTRIBUTING.html#detailed-development-process) to help with the final steps of the process. Completing the below tasks helps to ensure our reviewers can maximize their time on your code as well as making sure the admiral codebase remains robust and consistent.

Please check off each taskbox as an acknowledgment that you completed the task or check off that it is not relevant to your Pull Request. This checklist is part of the Github Action workflows and the Pull Request will not be merged into the `main` branch until you have checked off each task.

- [x] Place Closes #<insert_issue_number> into the beginning of your Pull Request Title (Use Edit button in top-right if you need to update)
- [x] Code is formatted according to the [tidyverse style guide](https://style.tidyverse.org/). Run `styler::style_file()` to style R and Rmd files
- [x] Updated relevant unit tests or have written new unit tests - not relevant (documentation-only change)
- [x] If you removed/replaced any function and/or function parameters, did you fully follow the [deprecation guidance](https://pharmaverse.github.io/admiraldev/articles/programming_strategy.html#deprecation)? - not relevant (no function/parameter changes)
- [x] Review the [Cheat Sheet](https://github.com/pharmaverse/admiral/blob/main/inst/cheatsheet/admiral_cheatsheet.pdf) - reviewed, no update required
- [x] Update to all relevant roxygen headers and examples, including keywords and families
- [x] Run `devtools::document()` so all `.Rd` files in the `man` folder and the `NAMESPACE` file in the project root are updated appropriately - `man/derive_expected_records.Rd` regenerated
- [x] Address any updates needed for vignettes and/or templates - reviewed `questionnaires.Rmd` usage, no update needed
- [x] Update `NEWS.md` under the header `# admiral (development version)` (Documentation section)
- [ ] Build admiral site `pkgdown::build_site()` - will confirm rendering via PR CI
- [x] Address or fix all lintr warnings and errors - `lintr::lint_package()`
- [ ] Run `R CMD check` locally and address all errors and warnings - will confirm via PR CI
- [x] Link the issue in the Development Section on the right hand side.
- [x] Address all merge conflicts and resolve appropriately
- [x] Pat yourself on the back for a job well done! Much love to your accomplishment!
