### PR TITLE
Closes #3188: derive vars merged lookup warning if some not mapped

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -17,9 +17,10 @@ accordingly).
     a Particular Date" section of the "Date and Time Imputation" vignette
     (`vignette("imputation")`) for details and examples. (#2708)
     
-- `derive_vars_merged_lookup()` was enhanced with a new `warn_not_mapped` argument
-which allows users to control whether a warning is issued when some records are not
-mapped using the lookup dataset. (#3188)
+- `derive_vars_merged_lookup()` was enhanced with a new `check_not_mapped_type` argument
+which allows users to control whether if a message, warning, error, or no message at all
+is issued when some records are not mapped using the lookup dataset. The `print_not_mapped`
+argument will thus be deprecated. (#3188)
 
 ## Breaking Changes
 
@@ -27,7 +28,8 @@ mapped using the lookup dataset. (#3188)
 
   **Phase 1 (message)**
 
-  No functions or arguments in this phase.
+  - `derive_vars_merged_lookup(print_not_mapped = )` is deprecated in favor of the 
+  `check_not_mapped_type` argument.
 
   **Phase 2 (warning)**
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -16,6 +16,10 @@ accordingly).
     See the `derive_vars_dt()` documentation and the "Avoid Imputed Dates Before
     a Particular Date" section of the "Date and Time Imputation" vignette
     (`vignette("imputation")`) for details and examples. (#2708)
+    
+- `derive_vars_merged_lookup()` was enhanced with a new `warn_not_mapped` argument
+which allows users to control whether a warning is issued when some records are not
+mapped using the lookup dataset. (#3188)
 
 ## Breaking Changes
 

--- a/R/derive_merged.R
+++ b/R/derive_merged.R
@@ -692,9 +692,9 @@ derive_var_merged_exist_flag <- function(dataset,
   new_var <- assert_symbol(enexpr(new_var))
   filter_add <- assert_filter_cond(enexpr(filter_add), optional = TRUE)
   add_data <- get_flagged_records(dataset_add,
-    new_var = !!new_var,
-    condition = !!condition,
-    !!filter_add
+                                  new_var = !!new_var,
+                                  condition = !!condition,
+                                  !!filter_add
   )
 
   derive_vars_merged(
@@ -723,6 +723,9 @@ derive_var_merged_exist_flag <- function(dataset,
 #'
 #' @param print_not_mapped Print a list of unique `by_vars` values that do not
 #' have corresponding records from the lookup table?
+#'
+#' @param warn_not_mapped Issue a warning if some records from the input dataset
+#' are not mapped?
 #'
 #' @permitted [boolean]
 #'
@@ -793,7 +796,8 @@ derive_vars_merged_lookup <- function(dataset,
                                       filter_add = NULL,
                                       check_type = "warning",
                                       duplicate_msg = NULL,
-                                      print_not_mapped = TRUE) {
+                                      print_not_mapped = TRUE,
+                                      warn_not_mapped = FALSE) {
   by_vars_left <- replace_values_by_names(by_vars)
   assert_logical_scalar(print_not_mapped)
   filter_add <- assert_filter_cond(enexpr(filter_add), optional = TRUE)
@@ -813,29 +817,43 @@ derive_vars_merged_lookup <- function(dataset,
     duplicate_msg = duplicate_msg
   )
 
-  if (print_not_mapped) {
+  if (print_not_mapped || warn_not_mapped) {
+
     temp_not_mapped <- res %>%
       filter(is.na(!!tmp_lookup_flag)) %>%
       distinct(!!!by_vars_left)
+    some_not_mapped <- nrow(temp_not_mapped) > 0
 
-    if (nrow(temp_not_mapped) > 0) {
-      # nolint start: undesirable_function_linter
-      admiral_environment$nmap <- structure(
-        temp_not_mapped,
-        class = union("nmap", class(temp_not_mapped)),
-        by_vars = vars2chr(by_vars_left)
-      )
-      # nolint end
+    if(print_not_mapped){
 
-      cli_inform(
-        c("List of {.var {vars2chr(by_vars_left)}} not mapped:",
-          capture.output(temp_not_mapped),
+      if (some_not_mapped) {
+        # nolint start: undesirable_function_linter
+        admiral_environment$nmap <- structure(
+          temp_not_mapped,
+          class = union("nmap", class(temp_not_mapped)),
+          by_vars = vars2chr(by_vars_left)
+        )
+        # nolint end
+
+        if(warn_not_mapped) cli_function <- cli_warn else cli_function <- cli_inform
+
+        cli_function(
+          c("List of {.var {vars2chr(by_vars_left)}} not mapped:",
+            capture.output(temp_not_mapped),
+            i = "Run {.run admiral::get_not_mapped()} to access the full list."
+          )
+        )
+      } else {
+        cli_inform(
+          "All {.var {vars2chr(by_vars_left)}} are mapped."
+        )
+      }
+
+    }else if(some_not_mapped && warn_not_mapped){
+      cli_warn(
+        c("Some {.var {vars2chr(by_vars_left)}} are not mapped.",
           i = "Run {.run admiral::get_not_mapped()} to access the full list."
         )
-      )
-    } else if (nrow(temp_not_mapped) == 0) {
-      cli_inform(
-        "All {.var {vars2chr(by_vars_left)}} are mapped."
       )
     }
   }

--- a/R/derive_merged.R
+++ b/R/derive_merged.R
@@ -692,9 +692,9 @@ derive_var_merged_exist_flag <- function(dataset,
   new_var <- assert_symbol(enexpr(new_var))
   filter_add <- assert_filter_cond(enexpr(filter_add), optional = TRUE)
   add_data <- get_flagged_records(dataset_add,
-                                  new_var = !!new_var,
-                                  condition = !!condition,
-                                  !!filter_add
+    new_var = !!new_var,
+    condition = !!condition,
+    !!filter_add
   )
 
   derive_vars_merged(
@@ -828,7 +828,6 @@ derive_vars_merged_lookup <- function(dataset,
   )
 
   if ((!is.null(print_not_mapped) && print_not_mapped) || check_not_mapped_type != "none") {
-
     # Identify if any unmapped records exist
     temp_not_mapped <- res %>%
       filter(is.na(!!tmp_lookup_flag)) %>%
@@ -837,7 +836,7 @@ derive_vars_merged_lookup <- function(dataset,
     some_not_mapped <- nrow(temp_not_mapped) > 0
 
     # Store unmapped records
-    if(some_not_mapped){
+    if (some_not_mapped) {
       # nolint start: undesirable_function_linter
       admiral_environment$nmap <- structure(
         temp_not_mapped,
@@ -847,19 +846,20 @@ derive_vars_merged_lookup <- function(dataset,
       # nolint end
     }
 
-    if(!is.null(print_not_mapped)){
+    if (!is.null(print_not_mapped)) {
       deprecate_inform(
         when = "1.6.0",
         what = "derive_vars_merged_lookup(print_not_mapped)",
         with = "derive_vars_merged_lookup(check_not_mapped_type)",
         details = c(
           x = "This message will turn into a warning at the beginning of 2028.",
+          # nolint start: line_length_linter
           i = "See admiral's deprecation guidance:
               https://pharmaverse.github.io/admiraldev/dev/articles/programming_strategy.html#deprecation"
+          # nolint end: line_length_linter
         )
       )
       if (print_not_mapped && some_not_mapped) {
-
         cli_inform(
           c("List of {.var {vars2chr(by_vars_left)}} not mapped:",
             capture.output(temp_not_mapped),
@@ -874,9 +874,7 @@ derive_vars_merged_lookup <- function(dataset,
     }
 
     if (check_not_mapped_type != "none" && some_not_mapped) {
-
-      cli_function <- switch(
-        check_not_mapped_type,
+      cli_function <- switch(check_not_mapped_type,
         warning = cli_warn,
         message = cli_inform,
         error = cli_abort

--- a/R/derive_merged.R
+++ b/R/derive_merged.R
@@ -721,13 +721,17 @@ derive_var_merged_exist_flag <- function(dataset,
 #'
 #' @permitted [dataset]
 #'
-#' @param print_not_mapped Print a list of unique `by_vars` values that do not
-#' have corresponding records from the lookup table?
-#'
-#' @param warn_not_mapped Issue a warning if some records from the input dataset
-#' are not mapped?
+#' @param print_not_mapped `r lifecycle::badge("deprecated")` Print a list of unique
+#' `by_vars` values that do not have corresponding records from the lookup table?
 #'
 #' @permitted [boolean]
+#'
+#' @param check_not_mapped_type Check if any observations are not mapped?
+#'
+#'   If `"warning"`, `"message"`, or `"error"` is specified, the specified message is issued
+#'   if some records from the input dataset are not mapped using the lookup table.
+#'
+#' @permitted [msg_type]
 #'
 #' @inheritParams derive_vars_merged
 #'
@@ -796,11 +800,17 @@ derive_vars_merged_lookup <- function(dataset,
                                       filter_add = NULL,
                                       check_type = "warning",
                                       duplicate_msg = NULL,
-                                      print_not_mapped = TRUE,
-                                      warn_not_mapped = FALSE) {
+                                      print_not_mapped = NULL,
+                                      check_not_mapped_type = "message") {
   by_vars_left <- replace_values_by_names(by_vars)
-  assert_logical_scalar(print_not_mapped)
+  assert_logical_scalar(print_not_mapped, optional = TRUE)
   filter_add <- assert_filter_cond(enexpr(filter_add), optional = TRUE)
+  check_not_mapped_type <-
+    assert_character_scalar(
+      check_not_mapped_type,
+      values = c("none", "warning", "error", "message"),
+      case_sensitive = FALSE
+    )
 
   tmp_lookup_flag <- get_new_tmp_var(dataset_add, prefix = "tmp_lookup_flag")
 
@@ -817,27 +827,40 @@ derive_vars_merged_lookup <- function(dataset,
     duplicate_msg = duplicate_msg
   )
 
-  if (print_not_mapped || warn_not_mapped) {
+  if ((!is.null(print_not_mapped) && print_not_mapped) || check_not_mapped_type != "none") {
 
+    # Identify if any unmapped records exist
     temp_not_mapped <- res %>%
       filter(is.na(!!tmp_lookup_flag)) %>%
       distinct(!!!by_vars_left)
+
     some_not_mapped <- nrow(temp_not_mapped) > 0
 
-    if(print_not_mapped){
+    # Store unmapped records
+    if(some_not_mapped){
+      # nolint start: undesirable_function_linter
+      admiral_environment$nmap <- structure(
+        temp_not_mapped,
+        class = union("nmap", class(temp_not_mapped)),
+        by_vars = vars2chr(by_vars_left)
+      )
+      # nolint end
+    }
 
-      if (some_not_mapped) {
-        # nolint start: undesirable_function_linter
-        admiral_environment$nmap <- structure(
-          temp_not_mapped,
-          class = union("nmap", class(temp_not_mapped)),
-          by_vars = vars2chr(by_vars_left)
+    if(!is.null(print_not_mapped)){
+      deprecate_inform(
+        when = "1.6.0",
+        what = "derive_vars_merged_lookup(print_not_mapped)",
+        with = "derive_vars_merged_lookup(check_not_mapped_type)",
+        details = c(
+          x = "This message will turn into a warning at the beginning of 2028.",
+          i = "See admiral's deprecation guidance:
+              https://pharmaverse.github.io/admiraldev/dev/articles/programming_strategy.html#deprecation"
         )
-        # nolint end
+      )
+      if (print_not_mapped && some_not_mapped) {
 
-        if(warn_not_mapped) cli_function <- cli_warn else cli_function <- cli_inform
-
-        cli_function(
+        cli_inform(
           c("List of {.var {vars2chr(by_vars_left)}} not mapped:",
             capture.output(temp_not_mapped),
             i = "Run {.run admiral::get_not_mapped()} to access the full list."
@@ -848,12 +871,26 @@ derive_vars_merged_lookup <- function(dataset,
           "All {.var {vars2chr(by_vars_left)}} are mapped."
         )
       }
+    }
 
-    }else if(some_not_mapped && warn_not_mapped){
-      cli_warn(
-        c("Some {.var {vars2chr(by_vars_left)}} are not mapped.",
+    if (check_not_mapped_type != "none" && some_not_mapped) {
+
+      cli_function <- switch(
+        check_not_mapped_type,
+        warning = cli_warn,
+        message = cli_inform,
+        error = cli_abort
+      )
+
+      cli_function(
+        c("List of {.var {vars2chr(by_vars_left)}} not mapped:",
+          capture.output(temp_not_mapped),
           i = "Run {.run admiral::get_not_mapped()} to access the full list."
         )
+      )
+    } else if (check_not_mapped_type != "none" && !some_not_mapped) {
+      cli_inform(
+        "All {.var {vars2chr(by_vars_left)}} are mapped."
       )
     }
   }

--- a/inst/WORDLIST
+++ b/inst/WORDLIST
@@ -360,6 +360,7 @@ estimand
 estimands
 evaluable
 exprs
+failsafe
 fil
 findable
 fmt

--- a/inst/templates/ad_adeg.R
+++ b/inst/templates/ad_adeg.R
@@ -94,7 +94,8 @@ adeg <- adeg %>%
   derive_vars_merged_lookup(
     dataset_add = param_lookup,
     new_vars = exprs(PARAMCD),
-    by_vars = exprs(EGTESTCD)
+    by_vars = exprs(EGTESTCD),
+    check_not_mapped_type = "none"
   ) %>%
   ## Calculate AVAL and AVALC ----
   mutate(

--- a/inst/templates/ad_adlb.R
+++ b/inst/templates/ad_adlb.R
@@ -107,7 +107,7 @@ adlb <- adlb %>%
     new_vars = exprs(PARAMCD, PARAM, PARAMN),
     by_vars = exprs(LBTESTCD),
     check_type = "none",
-    print_not_mapped = FALSE
+    check_not_mapped_type = "none"
   ) %>%
   ## Calculate PARCAT1 AVAL AVALC ANRLO ANRHI ----
   mutate(

--- a/inst/templates/ad_advs.R
+++ b/inst/templates/ad_advs.R
@@ -83,7 +83,8 @@ advs <- advs %>%
   derive_vars_merged_lookup(
     dataset_add = param_lookup,
     new_vars = exprs(PARAMCD),
-    by_vars = exprs(VSTESTCD)
+    by_vars = exprs(VSTESTCD),
+    check_not_mapped_type = "none"
   ) %>%
   ## Calculate AVAL and AVALC ----
   # AVALC should only be mapped if it contains non-redundant information.

--- a/man/derive_vars_merged_lookup.Rd
+++ b/man/derive_vars_merged_lookup.Rd
@@ -15,7 +15,7 @@ derive_vars_merged_lookup(
   check_type = "warning",
   duplicate_msg = NULL,
   print_not_mapped = TRUE,
-  warn_not_mapped = FALSE
+  check_not_mapped_type = "none"
 )
 }
 \arguments{
@@ -146,19 +146,22 @@ If the uniqueness check fails, the specified message is displayed.
 }\if{html}{\out{</div>}}}
 }}
 
-\item{print_not_mapped}{Print a list of unique \code{by_vars} values that do not
-have corresponding records from the lookup table?
-
-\describe{
-\item{Default value}{\code{TRUE}}
-}}
-
-\item{warn_not_mapped}{Issue a warning if some records from the input dataset
-are not mapped?
+\item{print_not_mapped}{\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}} Print a list of unique
+\code{by_vars} values that do not have corresponding records from the lookup table?
 
 \describe{
 \item{Permitted values}{\code{TRUE}, \code{FALSE}}
-\item{Default value}{\code{FALSE}}
+\item{Default value}{\code{TRUE}}
+}}
+
+\item{check_not_mapped_type}{Check if any observations are not mapped?
+
+If \code{"warning"}, \code{"message"}, or \code{"error"} is specified, the specified message is issued
+if some records from the input dataset are not mapped using the lookup table.
+
+\describe{
+\item{Permitted values}{\code{"none"}, \code{"message"}, \code{"warning"}, \code{"error"}}
+\item{Default value}{\code{"none"}}
 }}
 }
 \value{

--- a/man/derive_vars_merged_lookup.Rd
+++ b/man/derive_vars_merged_lookup.Rd
@@ -14,7 +14,8 @@ derive_vars_merged_lookup(
   filter_add = NULL,
   check_type = "warning",
   duplicate_msg = NULL,
-  print_not_mapped = TRUE
+  print_not_mapped = TRUE,
+  warn_not_mapped = FALSE
 )
 }
 \arguments{
@@ -149,8 +150,15 @@ If the uniqueness check fails, the specified message is displayed.
 have corresponding records from the lookup table?
 
 \describe{
-\item{Permitted values}{\code{TRUE}, \code{FALSE}}
 \item{Default value}{\code{TRUE}}
+}}
+
+\item{warn_not_mapped}{Issue a warning if some records from the input dataset
+are not mapped?
+
+\describe{
+\item{Permitted values}{\code{TRUE}, \code{FALSE}}
+\item{Default value}{\code{FALSE}}
 }}
 }
 \value{

--- a/man/derive_vars_merged_lookup.Rd
+++ b/man/derive_vars_merged_lookup.Rd
@@ -14,8 +14,8 @@ derive_vars_merged_lookup(
   filter_add = NULL,
   check_type = "warning",
   duplicate_msg = NULL,
-  print_not_mapped = TRUE,
-  check_not_mapped_type = "none"
+  print_not_mapped = NULL,
+  check_not_mapped_type = "message"
 )
 }
 \arguments{
@@ -151,7 +151,7 @@ If the uniqueness check fails, the specified message is displayed.
 
 \describe{
 \item{Permitted values}{\code{TRUE}, \code{FALSE}}
-\item{Default value}{\code{TRUE}}
+\item{Default value}{\code{NULL}}
 }}
 
 \item{check_not_mapped_type}{Check if any observations are not mapped?
@@ -161,7 +161,7 @@ if some records from the input dataset are not mapped using the lookup table.
 
 \describe{
 \item{Permitted values}{\code{"none"}, \code{"message"}, \code{"warning"}, \code{"error"}}
-\item{Default value}{\code{"none"}}
+\item{Default value}{\code{"message"}}
 }}
 }
 \value{

--- a/tests/testthat/_snaps/derive_merged.md
+++ b/tests/testthat/_snaps/derive_merged.md
@@ -88,8 +88,9 @@
     Code
       actual <- derive_vars_merged_lookup(vs, dataset_add = param_lookup, by_vars = exprs(
         VSTESTCD, VSTEST), new_var = exprs(PARAMCD, PARAM = DESCRIPTION),
-      print_not_mapped = TRUE)
-    Message
+      check_not_mapped_type = "warning")
+    Condition
+      Warning:
       List of `VSTESTCD` and `VSTEST` not mapped:
       # A tibble: 1 x 2
       VSTESTCD VSTEST
@@ -102,7 +103,7 @@
     Code
       actual <- derive_vars_merged_lookup(vs, dataset_add = param_lookup, by_vars = exprs(
         VSTESTCD = TESTCD, VSTEST), new_var = exprs(PARAMCD, PARAM = DESCRIPTION),
-      print_not_mapped = TRUE)
+      check_not_mapped_type = "message")
     Message
       List of `VSTESTCD` and `VSTEST` not mapped:
       # A tibble: 1 x 2
@@ -111,12 +112,35 @@
       1 DIABP Diastolic Blood Pressure
       i Run `admiral::get_not_mapped()` to access the full list.
 
-# get_not_mapped Test 24: not all by_vars have records in the lookup table
+# derive_vars_merged_lookup Test 24: deperecation message for print_not_mapped argument
+
+    Code
+      derive_vars_merged_lookup(vs, dataset_add = param_lookup, by_vars = exprs(
+        VSTESTCD, VSTEST), new_var = exprs(PARAMCD, PARAM = DESCRIPTION),
+      check_not_mapped_type = "message")
+    Message
+      List of `VSTESTCD` and `VSTEST` not mapped:
+      # A tibble: 1 x 2
+      VSTESTCD VSTEST
+      <chr> <chr>
+      1 DIABP Diastolic Blood Pressure
+      i Run `admiral::get_not_mapped()` to access the full list.
+    Output
+      # A tibble: 5 x 8
+        USUBJID VSTESTCD VSTEST                   VSORRES VSSEQ STUDYID PARAMCD PARAM 
+        <chr>   <chr>    <chr>                      <dbl> <dbl> <chr>   <chr>   <chr> 
+      1 ST42-1  DIABP    Diastolic Blood Pressure      64     1 ST42    <NA>    <NA>  
+      2 ST42-1  DIABP    Diastolic Blood Pressure      83     2 ST42    <NA>    <NA>  
+      3 ST42-1  WEIGHT   Weight                       120     3 ST42    WEIGHT  Weigh~
+      4 ST42-2  WEIGHT   Weight                       110     1 ST42    WEIGHT  Weigh~
+      5 ST42-2  HEIGHT   Height                        58     2 ST42    HEIGHT  Heigh~
+
+# get_not_mapped Test 25: not all by_vars have records in the lookup table
 
     Code
       act_vs_param <- derive_vars_merged_lookup(vs, dataset_add = param_lookup,
         by_vars = exprs(VSTESTCD, VSTEST), new_var = exprs(PARAMCD, PARAM = DESCRIPTION),
-        print_not_mapped = TRUE)
+        check_not_mapped_type = "message")
     Message
       List of `VSTESTCD` and `VSTEST` not mapped:
       # A tibble: 1 x 2
@@ -125,7 +149,7 @@
       1 DIABP Diastolic Blood Pressure
       i Run `admiral::get_not_mapped()` to access the full list.
 
-# derive_vars_merged_summary Test 28: error if no summary function
+# derive_vars_merged_summary Test 29: error if no summary function
 
     Code
       derive_vars_merged_summary(adbds, dataset_add = adbds, by_vars = exprs(AVISIT),
@@ -136,7 +160,7 @@
       Please check the `new_vars` argument if summary functions like `mean()`, `sum()`, ... are used on the right hand side.
       i Run `admiral::get_duplicates_dataset()` to access the duplicate records
 
-# derive_var_merged_summary Test 32: error if no summary function
+# derive_var_merged_summary Test 33: error if no summary function
 
     Code
       derive_var_merged_summary(adbds, dataset_add = adbds, by_vars = exprs(AVISIT),

--- a/tests/testthat/_snaps/derive_merged.md
+++ b/tests/testthat/_snaps/derive_merged.md
@@ -117,13 +117,25 @@
     Code
       derive_vars_merged_lookup(vs, dataset_add = param_lookup, by_vars = exprs(
         VSTESTCD, VSTEST), new_var = exprs(PARAMCD, PARAM = DESCRIPTION),
-      check_not_mapped_type = "message")
+      print_not_mapped = TRUE)
     Message
+      The `print_not_mapped` argument of `derive_vars_merged_lookup()` is deprecated as of admiral 1.6.0.
+      i Please use the `check_not_mapped_type` argument instead.
+      x This message will turn into a warning at the beginning of 2028.
+      i See admiral's deprecation guidance: https://pharmaverse.github.io/admiraldev/dev/articles/programming_strategy.html#deprecation
       List of `VSTESTCD` and `VSTEST` not mapped:
-      # A tibble: 1 x 2
+      # A tibble: 2 x 2
       VSTESTCD VSTEST
       <chr> <chr>
       1 DIABP Diastolic Blood Pressure
+      2 HEIGHT Height
+      i Run `admiral::get_not_mapped()` to access the full list.
+      List of `VSTESTCD` and `VSTEST` not mapped:
+      # A tibble: 2 x 2
+      VSTESTCD VSTEST
+      <chr> <chr>
+      1 DIABP Diastolic Blood Pressure
+      2 HEIGHT Height
       i Run `admiral::get_not_mapped()` to access the full list.
     Output
       # A tibble: 5 x 8
@@ -133,7 +145,7 @@
       2 ST42-1  DIABP    Diastolic Blood Pressure      83     2 ST42    <NA>    <NA>  
       3 ST42-1  WEIGHT   Weight                       120     3 ST42    WEIGHT  Weigh~
       4 ST42-2  WEIGHT   Weight                       110     1 ST42    WEIGHT  Weigh~
-      5 ST42-2  HEIGHT   Height                        58     2 ST42    HEIGHT  Heigh~
+      5 ST42-2  HEIGHT   Height                        58     2 ST42    <NA>    <NA>  
 
 # get_not_mapped Test 25: not all by_vars have records in the lookup table
 

--- a/tests/testthat/test-derive_merged.R
+++ b/tests/testthat/test-derive_merged.R
@@ -733,14 +733,13 @@ test_that("derive_vars_merged_lookup Test 21: merge lookup table", {
       dataset_add = param_lookup,
       by_vars = exprs(VSTESTCD, VSTEST),
       new_var = exprs(PARAMCD, PARAM = DESCRIPTION),
-      print_not_mapped = TRUE
+      check_not_mapped_type = "warning"
     )
   )
 
   expected <-
     left_join(vs, param_lookup, by = c("VSTESTCD", "VSTEST")) %>%
     rename(PARAM = DESCRIPTION)
-
 
   expect_dfs_equal(
     base = expected,
@@ -751,8 +750,8 @@ test_that("derive_vars_merged_lookup Test 21: merge lookup table", {
 
 
 ## the lookup table
-## Test 22:  all by_vars have records in the lookup table ----
-test_that("derive_vars_merged_lookup Test 22:  all by_vars have records in the lookup table", {
+## Test 22: all by_vars have records in the lookup table ----
+test_that("derive_vars_merged_lookup Test 22: all by_vars have records in the lookup table", {
   vs <- tibble::tribble(
     ~USUBJID, ~VSTESTCD, ~VSTEST,                    ~VSORRES, ~VSSEQ,
     "ST42-1", "DIABP",   "Diastolic Blood Pressure",       64,      1,
@@ -779,7 +778,7 @@ test_that("derive_vars_merged_lookup Test 22:  all by_vars have records in the l
       dataset_add = param_lookup,
       by_vars = exprs(VSTESTCD, VSTEST),
       new_var = exprs(PARAMCD, PARAM = DESCRIPTION),
-      print_not_mapped = TRUE
+      check_not_mapped_type = "message"
     ),
     regex = "All `VSTESTCD` and `VSTEST` are mapped."
   )
@@ -787,7 +786,6 @@ test_that("derive_vars_merged_lookup Test 22:  all by_vars have records in the l
   expected <-
     left_join(vs, param_lookup, by = c("VSTESTCD", "VSTEST")) %>%
     rename(PARAM = DESCRIPTION)
-
 
   expect_dfs_equal(
     base = expected,
@@ -823,7 +821,7 @@ test_that("derive_vars_merged_lookup Test 23: by_vars with rename", {
       dataset_add = param_lookup,
       by_vars = exprs(VSTESTCD = TESTCD, VSTEST),
       new_var = exprs(PARAMCD, PARAM = DESCRIPTION),
-      print_not_mapped = TRUE
+      check_not_mapped_type = "message"
     )
   )
 
@@ -838,10 +836,38 @@ test_that("derive_vars_merged_lookup Test 23: by_vars with rename", {
   )
 })
 
+## Test 24: deperecation message for print_not_mapped argument ----
+test_that("derive_vars_merged_lookup Test 24: deperecation message for print_not_mapped argument", {
+  vs <- tibble::tribble(
+    ~USUBJID, ~VSTESTCD, ~VSTEST,                    ~VSORRES, ~VSSEQ,
+    "ST42-1", "DIABP",   "Diastolic Blood Pressure",       64,      1,
+    "ST42-1", "DIABP",   "Diastolic Blood Pressure",       83,      2,
+    "ST42-1", "WEIGHT",  "Weight",                        120,      3,
+    "ST42-2", "WEIGHT",  "Weight",                        110,      1,
+    "ST42-2", "HEIGHT",  "Height",                         58,      2
+  ) %>% mutate(STUDYID = "ST42")
+
+  param_lookup <- tibble::tribble(
+    ~VSTESTCD, ~VSTEST,           ~PARAMCD, ~DESCRIPTION,
+    "WEIGHT",  "Weight",          "WEIGHT", "Weight (kg)",
+    "HEIGHT",  "Height",          "HEIGHT", "Height (cm)",
+    "BMI",     "Body Mass Index", "BMI",    "Body Mass Index(kg/m^2)"
+  )
+
+  expect_snapshot(
+    derive_vars_merged_lookup(
+      vs,
+      dataset_add = param_lookup,
+      by_vars = exprs(VSTESTCD, VSTEST),
+      new_var = exprs(PARAMCD, PARAM = DESCRIPTION),
+      check_not_mapped_type = "message"
+    )
+  )
+})
 
 # get_not_mapped ----
-## Test 24: not all by_vars have records in the lookup table ----
-test_that("get_not_mapped Test 24: not all by_vars have records in the lookup table", {
+## Test 25: not all by_vars have records in the lookup table ----
+test_that("get_not_mapped Test 25: not all by_vars have records in the lookup table", {
   vs <- tibble::tribble(
     ~USUBJID, ~VSTESTCD, ~VSTEST,                    ~VSORRES, ~VSSEQ,
     "ST42-1", "DIABP",   "Diastolic Blood Pressure",       64,      1,
@@ -867,7 +893,7 @@ test_that("get_not_mapped Test 24: not all by_vars have records in the lookup ta
       dataset_add = param_lookup,
       by_vars = exprs(VSTESTCD, VSTEST),
       new_var = exprs(PARAMCD, PARAM = DESCRIPTION),
-      print_not_mapped = TRUE
+      check_not_mapped_type = "message"
     )
   )
 
@@ -887,8 +913,8 @@ test_that("get_not_mapped Test 24: not all by_vars have records in the lookup ta
 })
 
 # derive_vars_merged_summary ----
-## Test 25: dataset == dataset_add, no filter ----
-test_that("derive_vars_merged_summary Test 25: dataset == dataset_add, no filter", {
+## Test 26: dataset == dataset_add, no filter ----
+test_that("derive_vars_merged_summary Test 26: dataset == dataset_add, no filter", {
   expected <- tibble::tribble(
     ~AVISIT,  ~ASEQ, ~AVAL, ~MEANVIS,
     "WEEK 1",     1,    10,       10,
@@ -914,8 +940,8 @@ test_that("derive_vars_merged_summary Test 25: dataset == dataset_add, no filter
   )
 })
 
-## Test 26: dataset != dataset_add, filter ----
-test_that("derive_vars_merged_summary Test 26: dataset != dataset_add, filter", {
+## Test 27: dataset != dataset_add, filter ----
+test_that("derive_vars_merged_summary Test 27: dataset != dataset_add, filter", {
   expected <- tibble::tribble(
     ~USUBJID, ~MEANPBL,
     "1",          13.5,
@@ -946,8 +972,8 @@ test_that("derive_vars_merged_summary Test 26: dataset != dataset_add, filter", 
   )
 })
 
-## Test 27: by_vars with rename ----
-test_that("derive_vars_merged_summary Test 27: by_vars with rename", {
+## Test 28: by_vars with rename ----
+test_that("derive_vars_merged_summary Test 28: by_vars with rename", {
   expected <- tibble::tribble(
     ~AVISIT,  ~ASEQ, ~AVAL, ~MEANVIS,
     "WEEK 1",     1,    10,       10,
@@ -974,8 +1000,8 @@ test_that("derive_vars_merged_summary Test 27: by_vars with rename", {
   )
 })
 
-## Test 28: error if no summary function ----
-test_that("derive_vars_merged_summary Test 28: error if no summary function", {
+## Test 29: error if no summary function ----
+test_that("derive_vars_merged_summary Test 29: error if no summary function", {
   adbds <- tibble::tribble(
     ~AVISIT,  ~ASEQ, ~AVAL,
     "WEEK 1",     1,    10,
@@ -999,8 +1025,8 @@ test_that("derive_vars_merged_summary Test 28: error if no summary function", {
 })
 
 # derive_var_merged_summary ----
-## Test 29: dataset == dataset_add, no filter ----
-test_that("derive_var_merged_summary Test 29: dataset == dataset_add, no filter", {
+## Test 30: dataset == dataset_add, no filter ----
+test_that("derive_var_merged_summary Test 30: dataset == dataset_add, no filter", {
   withr::local_options(list(lifecycle_verbosity = "quiet"))
 
   expected <- tibble::tribble(
@@ -1028,8 +1054,8 @@ test_that("derive_var_merged_summary Test 29: dataset == dataset_add, no filter"
   )
 })
 
-## Test 30: dataset != dataset_add, filter ----
-test_that("derive_var_merged_summary Test 30: dataset != dataset_add, filter", {
+## Test 31: dataset != dataset_add, filter ----
+test_that("derive_var_merged_summary Test 31: dataset != dataset_add, filter", {
   withr::local_options(list(lifecycle_verbosity = "quiet"))
 
   expected <- tibble::tribble(
@@ -1062,8 +1088,8 @@ test_that("derive_var_merged_summary Test 30: dataset != dataset_add, filter", {
   )
 })
 
-## Test 31: by_vars with rename ----
-test_that("derive_var_merged_summary Test 31: by_vars with rename", {
+## Test 32: by_vars with rename ----
+test_that("derive_var_merged_summary Test 32: by_vars with rename", {
   withr::local_options(list(lifecycle_verbosity = "quiet"))
 
   expected <- tibble::tribble(
@@ -1092,8 +1118,8 @@ test_that("derive_var_merged_summary Test 31: by_vars with rename", {
   )
 })
 
-## Test 32: error if no summary function ----
-test_that("derive_var_merged_summary Test 32: error if no summary function", {
+## Test 33: error if no summary function ----
+test_that("derive_var_merged_summary Test 33: error if no summary function", {
   withr::local_options(list(lifecycle_verbosity = "quiet"))
 
   adbds <- tibble::tribble(
@@ -1118,8 +1144,8 @@ test_that("derive_var_merged_summary Test 32: error if no summary function", {
   )
 })
 
-## Test 33: deprecation warning ----
-test_that("derive_var_merged_summary Test 33: deprecation warning", {
+## Test 34: deprecation warning ----
+test_that("derive_var_merged_summary Test 34: deprecation warning", {
   expected <- tibble::tribble(
     ~AVISIT,  ~ASEQ, ~AVAL, ~MEANVIS,
     "WEEK 1",     1,    10,       10,

--- a/tests/testthat/test-derive_merged.R
+++ b/tests/testthat/test-derive_merged.R
@@ -850,7 +850,6 @@ test_that("derive_vars_merged_lookup Test 24: deperecation message for print_not
   param_lookup <- tibble::tribble(
     ~VSTESTCD, ~VSTEST,           ~PARAMCD, ~DESCRIPTION,
     "WEIGHT",  "Weight",          "WEIGHT", "Weight (kg)",
-    "HEIGHT",  "Height",          "HEIGHT", "Height (cm)",
     "BMI",     "Body Mass Index", "BMI",    "Body Mass Index(kg/m^2)"
   )
 
@@ -860,7 +859,7 @@ test_that("derive_vars_merged_lookup Test 24: deperecation message for print_not
       dataset_add = param_lookup,
       by_vars = exprs(VSTESTCD, VSTEST),
       new_var = exprs(PARAMCD, PARAM = DESCRIPTION),
-      check_not_mapped_type = "message"
+      print_not_mapped = TRUE
     )
   )
 })

--- a/vignettes/bds_finding.Rmd
+++ b/vignettes/bds_finding.Rmd
@@ -238,7 +238,8 @@ advs <- derive_vars_merged_lookup(
   advs,
   dataset_add = param_lookup,
   new_vars = exprs(PARAMCD),
-  by_vars = exprs(VSTESTCD)
+  by_vars = exprs(VSTESTCD),
+  check_not_mapped_type = "message"
 )
 ```
 
@@ -255,6 +256,11 @@ necessary to expand this lookup or create a separate look up for `PARAMCD`.
 If more than one lookup table, e.g., company parameter mappings and project
 parameter mappings, are available, `consolidate_metadata()` can be used to
 consolidate these into a single lookup table.
+
+The `check_not_mapped_type` argument can be used to control whether a message, 
+warning, error, or no message at all is issued when some records are not mapped.
+This can be useful as a failsafe in the case that it is expected that all records 
+should be mapped using the lookup table.
 
 Additionally note that each parameter is mapped to only one `PARCAT1` variable. 
 This is described in section 3.3.4.1 of the ADaM Implementation Guide, 


### PR DESCRIPTION
Thank you for your Pull Request! We have developed this task checklist from the [Development Process Guide](https://pharmaverse.github.io/admiral/cran-release/CONTRIBUTING.html#detailed-development-process) to help with the final steps of the process. Completing the below tasks helps to ensure our reviewers can maximize their time on your code as well as making sure the admiral codebase remains robust and consistent.   

Please check off each taskbox as an acknowledgment that you completed the task or check off that it is not relevant to your Pull Request. This checklist is part of the Github Action workflows and the Pull Request will not be merged into the `main` branch until you have checked off each task.

- [x] Place Closes #<insert_issue_number> into the beginning of your Pull Request Title (Use Edit button in top-right if you need to update)
- [x] Code is formatted according to the [tidyverse style guide](https://style.tidyverse.org/). Run `styler::style_file()` to style R and Rmd files
- [x] Updated relevant unit tests or have written new unit tests, which should consider realistic data scenarios and edge cases, e.g. empty datasets, errors, boundary cases etc. - See [Unit Test Guide](https://pharmaverse.github.io/admiraldev/articles/unit_test_guidance.html#tests-should-be-robust-to-cover-realistic-data-scenarios)
- [x] If you removed/replaced any function and/or function parameters, did you fully follow the [deprecation guidance](https://pharmaverse.github.io/admiraldev/articles/programming_strategy.html#deprecation)?
- [x] Review the [Cheat Sheet](https://github.com/pharmaverse/admiral/blob/main/inst/cheatsheet/admiral_cheatsheet.pdf). Make any required updates to it by editing the file `inst/cheatsheet/admiral_cheatsheet.pptx` and re-upload a PDF and a PNG version of it to the same folder. (The PNG version can be created by taking a screenshot of the PDF version.)
- [x] Update to all relevant roxygen headers and examples, including keywords and families. Refer to the [categorization of functions](https://pharmaverse.github.io/admiraldev/articles/programming_strategy.html#categorization-of-functions) to tag appropriate keyword/family.
- [x] Run `devtools::document()` so all `.Rd` files in the `man` folder and the `NAMESPACE` file in the project root are updated appropriately
- [x] Address any updates needed for vignettes and/or templates
- [x] Update `NEWS.md` under the header `# admiral (development version)` if the changes pertain to a user-facing function (i.e. it has an `@export` tag) or documentation aimed at users (rather than developers). A Developer Notes section is available in `NEWS.md` for tracking developer-facing issues.  
- [x] Build admiral site `pkgdown::build_site()` and check that all affected examples are displayed correctly and that all new functions occur on the "[Reference](https://pharmaverse.github.io/admiral/cran-release/reference/index.html)" page. 
- [x] Address or fix all lintr warnings and errors - `lintr::lint_package()`
- [x] Run `R CMD check` locally and address all errors and warnings - `devtools::check()`
- [x] Link the issue in the Development Section on the right hand side.
- [x] Address all merge conflicts and resolve appropriately
- [x] Pat yourself on the back for a job well done! Much love to your accomplishment!

To create the website for the content of this PR add "[create website]" to the title of the pull request.
